### PR TITLE
fix: align billing status UI and auth theme support

### DIFF
--- a/components/OfficeSetup.tsx
+++ b/components/OfficeSetup.tsx
@@ -64,14 +64,14 @@ export default function OfficeSetup() {
   };
 
   return (
-    <div className="min-h-screen bg-[#0C1421] py-8 px-4 sm:px-6 lg:px-8">
+    <div className="min-h-screen bg-slate-50 py-8 px-4 sm:px-6 lg:px-8 dark:bg-[#0C1421]">
       <div className="max-w-2xl mx-auto">
         {/* ヘッダー */}
         <div className="text-center mb-8">
-          <h1 className="text-3xl font-bold text-white mb-2">
+          <h1 className="text-3xl font-bold text-slate-950 mb-2 dark:text-white">
             事業所情報の登録
           </h1>
-          <p className="text-gray-400">
+          <p className="text-slate-600 dark:text-gray-400">
             ケイカくんをご利用いただくため、事業所の基本情報を登録してください
           </p>
         </div>
@@ -80,27 +80,27 @@ export default function OfficeSetup() {
         <StepWizard steps={steps} />
 
         {/* フォーム */}
-        <div className="bg-[#2A2A2A] rounded-lg border border-gray-700 p-8">
+        <div className="bg-white rounded-lg border border-slate-200 p-8 shadow-sm dark:bg-[#2A2A2A] dark:border-gray-700">
           <form onSubmit={handleSubmit(onSubmit)} className="space-y-6">
             {errors.root && (
-              <div className="bg-red-500/10 border border-red-500/20 rounded-lg p-4 text-red-400 text-sm">
+              <div className="bg-red-50 border border-red-200 rounded-lg p-4 text-red-700 text-sm dark:bg-red-500/10 dark:border-red-500/20 dark:text-red-400">
                 {errors.root.message}
               </div>
             )}
 
             {/* 基本情報 */}
-            <div className="border-b border-gray-700 pb-6">
-              <h2 className="text-lg font-semibold text-white mb-4">基本情報</h2>
+            <div className="border-b border-slate-200 pb-6 dark:border-gray-700">
+              <h2 className="text-lg font-semibold text-slate-950 mb-4 dark:text-white">基本情報</h2>
               
               <div className="grid md:grid-cols-2 gap-4">
                 <div className="md:col-span-2">
-                  <label className="block text-sm font-medium text-gray-300 mb-2">
+                  <label className="block text-sm font-medium text-slate-700 mb-2 dark:text-gray-300">
                     事業所名 <span className="text-red-400">*</span>
                   </label>
                   <input
                     type="text"
                     {...register('name')}
-                    className="w-full px-3 py-2 bg-[#1A1A1A] border border-gray-600 rounded-lg text-white placeholder-gray-500 focus:outline-none focus:ring-2 focus:ring-[#10B981] focus:border-transparent"
+                    className="w-full px-3 py-2 bg-white border border-slate-300 rounded-lg text-slate-950 placeholder-slate-400 focus:outline-none focus:ring-2 focus:ring-[#10B981] focus:border-transparent dark:bg-[#1A1A1A] dark:border-gray-600 dark:text-white dark:placeholder-gray-500"
                     placeholder="○○就労移行支援事業所"
                   />
                   {errors.name && (
@@ -109,12 +109,12 @@ export default function OfficeSetup() {
                 </div>
 
                 <div>
-                  <label className="block text-sm font-medium text-gray-300 mb-2">
+                  <label className="block text-sm font-medium text-slate-700 mb-2 dark:text-gray-300">
                     事業所種別 <span className="text-red-400">*</span>
                   </label>
                   <select
                     {...register('type')}
-                    className="w-full px-3 py-2 bg-[#1A1A1A] border border-gray-600 rounded-lg text-white focus:outline-none focus:ring-2 focus:ring-[#10B981] focus:border-transparent"
+                    className="w-full px-3 py-2 bg-white border border-slate-300 rounded-lg text-slate-950 focus:outline-none focus:ring-2 focus:ring-[#10B981] focus:border-transparent dark:bg-[#1A1A1A] dark:border-gray-600 dark:text-white"
                   >
                     <option value="">選択してください</option>
                     {officeTypes.map(type => (
@@ -136,7 +136,7 @@ export default function OfficeSetup() {
               <button
                 type="button"
                 onClick={() => router.back()}
-                className="flex-1 border-2 border-gray-600 hover:border-gray-500 text-gray-300 hover:text-white font-semibold py-3 px-4 rounded-lg transition-colors duration-200"
+                className="flex-1 border-2 border-slate-300 hover:border-slate-400 text-slate-700 hover:text-slate-950 font-semibold py-3 px-4 rounded-lg transition-colors duration-200 dark:border-gray-600 dark:hover:border-gray-500 dark:text-gray-300 dark:hover:text-white"
               >
                 戻る
               </button>

--- a/components/SignupSuccess.tsx
+++ b/components/SignupSuccess.tsx
@@ -10,7 +10,7 @@ function SignupSuccessContent() {
   const loginUrl = role === 'owner' ? '/auth/admin/login' : '/auth/login';
 
   return (
-    <div className="min-h-screen bg-[#0C1421] flex items-center justify-center px-4 sm:px-6 lg:px-8">
+    <div className="min-h-screen bg-slate-50 flex items-center justify-center px-4 sm:px-6 lg:px-8 dark:bg-[#0C1421]">
       <div className="max-w-lg w-full text-center">
         {/* アイコン */}
         <div className="w-20 h-20 bg-[#10B981]/20 rounded-full flex items-center justify-center mx-auto mb-8">
@@ -18,24 +18,24 @@ function SignupSuccessContent() {
         </div>
 
         {/* メインメッセージ */}
-        <h1 className="text-3xl font-bold text-white mb-4">
+        <h1 className="text-3xl font-bold text-slate-950 mb-4 dark:text-white">
           アカウント作成完了！
         </h1>
         
-        <p className="text-lg text-gray-300 mb-8">
+        <p className="text-lg text-slate-700 mb-8 dark:text-gray-300">
           アカウントの作成が完了しました。
           <br />
           メール認証を行ってログインしてください。
         </p>
 
         {/* メール認証の説明 */}
-        <div className="bg-[#2A2A2A] rounded-lg border border-gray-700 p-6 mb-8 text-left">
-          <h2 className="text-xl font-semibold text-white mb-4 flex items-center">
+        <div className="bg-white rounded-lg border border-slate-200 p-6 mb-8 text-left shadow-sm dark:bg-[#2A2A2A] dark:border-gray-700">
+          <h2 className="text-xl font-semibold text-slate-950 mb-4 flex items-center dark:text-white">
             <span className="text-blue-400 mr-2">📧</span>
             次のステップ
           </h2>
           
-          <ol className="space-y-3 text-gray-300">
+          <ol className="space-y-3 text-slate-700 dark:text-gray-300">
             <li className="flex items-start">
               <span className="bg-[#10B981] text-white text-sm rounded-full w-6 h-6 flex items-center justify-center mr-3 mt-0.5 font-semibold">1</span>
               <span>登録されたメールアドレスに確認メールをお送りしました</span>
@@ -52,12 +52,12 @@ function SignupSuccessContent() {
         </div>
 
         {/* 注意事項 */}
-        <div className="bg-yellow-500/10 border border-yellow-500/20 rounded-lg p-4 mb-8">
+        <div className="bg-yellow-50 border border-yellow-200 rounded-lg p-4 mb-8 dark:bg-yellow-500/10 dark:border-yellow-500/20">
           <div className="flex items-start">
             <span className="text-yellow-400 text-lg mr-2">⚠️</span>
             <div className="text-left">
-              <h3 className="font-semibold text-yellow-400 mb-1">メールが届かない場合</h3>
-              <p className="text-yellow-300 text-sm">
+              <h3 className="font-semibold text-yellow-700 mb-1 dark:text-yellow-400">メールが届かない場合</h3>
+              <p className="text-yellow-800 text-sm dark:text-yellow-300">
                 迷惑メールフォルダをご確認ください。それでも届かない場合は、サポートまでお問い合わせください。
               </p>
             </div>
@@ -73,14 +73,14 @@ function SignupSuccessContent() {
             ログインページへ
           </a>
           
-          <button className="block w-full border-2 border-gray-600 hover:border-gray-500 text-gray-300 hover:text-white font-semibold py-3 px-6 rounded-lg transition-colors duration-200 hover:bg-gray-800/30">
+          <button className="block w-full border-2 border-slate-300 hover:border-slate-400 text-slate-700 hover:text-slate-950 font-semibold py-3 px-6 rounded-lg transition-colors duration-200 hover:bg-slate-100 dark:border-gray-600 dark:hover:border-gray-500 dark:text-gray-300 dark:hover:text-white dark:hover:bg-gray-800/30">
             確認メールを再送信
           </button>
         </div>
 
         {/* サポート情報 */}
         <div className="mt-8 text-center">
-          <p className="text-gray-400 text-sm mb-2">
+          <p className="text-slate-600 text-sm mb-2 dark:text-gray-400">
             ご不明な点がございましたら、お気軽にお問い合わせください
           </p>
           <div className="flex justify-center space-x-6 text-sm">

--- a/components/ui/StepWizard.tsx
+++ b/components/ui/StepWizard.tsx
@@ -26,26 +26,26 @@ export default function StepWizard({ steps, className = '' }: StepWizardProps) {
                   <div className="relative flex h-8 w-8 items-center justify-center rounded-full bg-[#10B981]">
                     <CheckIcon className="h-5 w-5 text-white" aria-hidden="true" />
                   </div>
-                  <span className="absolute top-10 w-max -translate-x-1/2 text-sm text-gray-300">{step.title}</span>
+                  <span className="absolute top-10 w-max -translate-x-1/2 text-sm text-slate-700 dark:text-gray-300">{step.title}</span>
                 </>
               ) : step.status === 'current' ? (
                 <>
-                  <div className="relative flex h-8 w-8 items-center justify-center rounded-full border-2 border-[#10B981] bg-[#2A2A2A]" aria-current="step">
+                  <div className="relative flex h-8 w-8 items-center justify-center rounded-full border-2 border-[#10B981] bg-white dark:bg-[#2A2A2A]" aria-current="step">
                     <span className="h-2.5 w-2.5 rounded-full bg-[#10B981]" />
                   </div>
                   <span className="absolute top-10 w-max -translate-x-1/2 text-sm font-semibold text-[#10B981]">{step.title}</span>
                 </>
               ) : (
                 <>
-                  <div className="group relative flex h-8 w-8 items-center justify-center rounded-full border-2 border-gray-600 bg-[#2A2A2A]">
+                  <div className="group relative flex h-8 w-8 items-center justify-center rounded-full border-2 border-slate-300 bg-white dark:border-gray-600 dark:bg-[#2A2A2A]">
                     <span className="h-2.5 w-2.5 rounded-full bg-transparent" />
                   </div>
-                  <span className="absolute top-10 w-max -translate-x-1/2 text-sm text-gray-500">{step.title}</span>
+                  <span className="absolute top-10 w-max -translate-x-1/2 text-sm text-slate-500 dark:text-gray-500">{step.title}</span>
                 </>
               )}
             </li>
             {stepIdx < steps.length - 1 && (
-              <li aria-hidden="true" className="px-4 text-gray-500 sm:px-8">
+              <li aria-hidden="true" className="px-4 text-slate-400 dark:text-gray-500 sm:px-8">
                 &gt;
               </li>
             )}


### PR DESCRIPTION
## Summary
- Align billing status UI handling for trial_expired, payment_failed, canceling, and canceled states
- Update paid membership management copy, restriction banners, and payment method guide modal
- Add light/dark theme support for auth office setup, signup success, and signup progress UI

## Tests
- npm run lint

## Notes
- Browser visual checks for the latest auth light/dark changes are still pending.