### PR TITLE
[codex] Add auth loading feedback and remove debug console output

### DIFF
--- a/app/(protected)/pdf-list/page.tsx
+++ b/app/(protected)/pdf-list/page.tsx
@@ -26,30 +26,24 @@ export default function PdfViewPage() {
   useEffect(() => {
     const fetchData = async () => {
       try {
-        console.log('[DEBUG] Fetching user data...');
         // 認証チェック
         const currentUser = await authApi.getCurrentUser();
-        console.log('[DEBUG] Current user:', currentUser);
         setUserRole(currentUser.role);
 
         // office_idの取得
         if (!currentUser.office?.id) {
-          console.error('[ERROR] User has no office associated');
           router.push('/auth/select-office');
           return;
         }
-        console.log('[DEBUG] Office ID:', currentUser.office.id);
         setOfficeId(currentUser.office.id);
 
         // URLパラメータ取得
         const page = Number(searchParams.get('page')) || 1;
         const search = searchParams.get('search') || '';
         const recipientId = searchParams.get('recipient') || '';
-        console.log('[DEBUG] URL params - page:', page, 'search:', search, 'recipientId:', recipientId);
 
         // PDF一覧取得
         const skip = (page - 1) * 20;
-        console.log('[DEBUG] Calling pdfDeliverablesApi.getList with skip:', skip);
         const data = await pdfDeliverablesApi.getList({
           office_id: currentUser.office.id,
           skip,
@@ -58,14 +52,9 @@ export default function PdfViewPage() {
           recipient_ids: recipientId && recipientId !== 'all' ? recipientId : undefined,
         });
 
-        console.log('[DEBUG] PDF data received:', data);
         setPdfData(data);
-      } catch (error) {
-        console.error('[ERROR] Failed to fetch data:', error);
-        if (error instanceof Error) {
-          console.error('[ERROR] Error message:', error.message);
-          console.error('[ERROR] Error stack:', error.stack);
-        }
+      } catch {
+        console.error('PDF一覧の取得に失敗しました');
         router.push('/auth/login');
       } finally {
         setIsLoading(false);

--- a/app/(protected)/recipients/[id]/edit/page.tsx
+++ b/app/(protected)/recipients/[id]/edit/page.tsx
@@ -20,9 +20,6 @@ export default function EditRecipientPage({ params }: { params: Promise<{ id: st
       setIsLoading(true);
       try {
         const data = await welfareRecipientsApi.get(resolvedParams.id);
-        console.log('[EditRecipientPage] Fetched recipient data:', data);
-        console.log('[EditRecipientPage] data.detail:', data.detail);
-        console.log('[EditRecipientPage] data.disability_status:', data.disability_status);
         setRecipient(data);
       } catch (err) {
         console.error('Failed to fetch recipient data:', err);

--- a/app/(protected)/recipients/[id]/page.tsx
+++ b/app/(protected)/recipients/[id]/page.tsx
@@ -50,8 +50,6 @@ export default function RecipientDetailPage({ params }: { params: Promise<{ id: 
       setIsLoadingUser(true);
       try {
         const userData = await authApi.getCurrentUser();
-        console.log('Current user data:', userData);
-        console.log('User role:', userData.role);
         setCurrentUser(userData);
       } catch (err) {
         console.error('Failed to fetch current user:', err);
@@ -109,21 +107,17 @@ export default function RecipientDetailPage({ params }: { params: Promise<{ id: 
 
   const canEditOrDelete = () => {
     if (!currentUser) {
-      console.log('canEditOrDelete: no currentUser');
       return false;
     }
     const canEdit = ['manager', 'owner'].includes(currentUser.role);
-    console.log(`canEditOrDelete: role=${currentUser.role}, canEdit=${canEdit}`);
     return canEdit;
   };
 
   const isEmployee = () => {
     if (!currentUser) {
-      console.log('isEmployee: no currentUser');
       return false;
     }
     const employeeCheck = currentUser.role === 'employee';
-    console.log(`isEmployee: role=${currentUser.role}, isEmployee=${employeeCheck}`);
     return employeeCheck;
   };
 

--- a/app/auth/mfa-verify/page.tsx
+++ b/app/auth/mfa-verify/page.tsx
@@ -3,6 +3,7 @@
 import { useState } from 'react';
 import { useRouter } from 'next/navigation';
 import { authApi, tokenUtils } from '@/lib/auth';
+import { useSlowLoadingMessage } from '@/hooks/useSlowLoadingMessage';
 
 export default function MfaVerifyPage() {
   const [totpCode, setTotpCode] = useState('');
@@ -10,6 +11,7 @@ export default function MfaVerifyPage() {
   const [error, setError] = useState('');
   const [verifyAttempts, setVerifyAttempts] = useState(0);
   const router = useRouter();
+  const showSlowLoadingMessage = useSlowLoadingMessage(isLoading);
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
@@ -115,10 +117,19 @@ export default function MfaVerifyPage() {
             <button
               type="submit"
               disabled={isLoading}
-              className="w-full bg-[#10B981] hover:bg-[#0F9F6E] text-white font-semibold py-3 px-4 rounded-lg transition-colors duration-200 shadow-lg hover:shadow-xl transform hover:-translate-y-0.5 disabled:opacity-50 disabled:cursor-not-allowed disabled:transform-none"
+              className="w-full bg-[#10B981] hover:bg-[#0F9F6E] text-white font-semibold py-3 px-4 rounded-lg transition-colors duration-200 shadow-lg hover:shadow-xl transform hover:-translate-y-0.5 disabled:opacity-50 disabled:cursor-not-allowed disabled:transform-none inline-flex items-center justify-center gap-2"
             >
+              {isLoading && (
+                <span className="h-4 w-4 animate-spin rounded-full border-2 border-white border-t-transparent" />
+              )}
               {isLoading ? '検証中...' : '検証'}
             </button>
+
+            {showSlowLoadingMessage && (
+              <p className="text-sm font-semibold text-slate-600 dark:text-gray-400">
+                認証に時間がかかっています。画面が変わらない場合は、通信状況を確認してページを更新してください。
+              </p>
+            )}
           </form>
         </div>
       </div>

--- a/app/auth/verify-email-change/page.tsx
+++ b/app/auth/verify-email-change/page.tsx
@@ -16,17 +16,13 @@ function VerifyEmailChangeContent() {
 
   useEffect(() => {
     if (!token) {
-      console.error('[DEBUG FRONT] No token found in URL');
+      console.error('メールアドレス変更トークンが見つかりません');
       return;
     }
 
-    console.log('[DEBUG FRONT] Token found:', token.substring(0, 10) + '...');
-
     const verify = async () => {
       try {
-        console.log('[DEBUG FRONT] Calling verifyEmailChange API...');
         const response = await profileApi.verifyEmailChange(token);
-        console.log('[DEBUG FRONT] API response:', response);
 
         setNewEmail(response.new_email);
         setStatus('success');
@@ -36,13 +32,10 @@ function VerifyEmailChangeContent() {
           router.push('/auth/login?message=メールアドレスを変更しました。新しいメールアドレスでログインしてください');
         }, 5000);
       } catch (err: unknown) {
-        console.error('[DEBUG FRONT] Error in verifyEmailChange:', err);
         setStatus('error');
         if (err instanceof Error) {
-          console.error('[DEBUG FRONT] Error message:', err.message);
           setError(err.message);
         } else {
-          console.error('[DEBUG FRONT] Unknown error:', err);
           setError('メールアドレスの変更に失敗しました。');
         }
       }

--- a/components/auth/LoginForm.tsx
+++ b/components/auth/LoginForm.tsx
@@ -27,23 +27,18 @@ export default function LoginForm() {
   useEffect(() => {
     // 既にメッセージを表示済みの場合はスキップ（重複防止）
     if (messageShownRef.current) {
-      console.log('📨 [LoginForm] メッセージは既に表示済みです。スキップします。');
       return;
     }
 
     const message = searchParams.get('message');
     if (message) {
-      console.log('📨 [LoginForm] クエリパラメータからメッセージを検出:', message);
-      console.log('📨 [LoginForm] toastを表示します');
       toast.success(decodeURIComponent(message));
-      console.log('📨 [LoginForm] toast.success呼び出し完了');
       messageShownRef.current = true; // 表示済みフラグを立てる
 
       // クエリパラメータをクリア
       const url = new URL(window.location.href);
       url.searchParams.delete('message');
       window.history.replaceState({}, '', url.toString());
-      console.log('📨 [LoginForm] クエリパラメータをクリアしました');
     }
   }, [searchParams]);
 

--- a/components/auth/LoginForm.tsx
+++ b/components/auth/LoginForm.tsx
@@ -6,6 +6,7 @@ import { authApi, tokenUtils } from '@/lib/auth';
 import { AiOutlineEye, AiOutlineEyeInvisible } from 'react-icons/ai'; // アイコンをインポート
 import { toast } from '@/lib/toast-debug';
 import DeletedOfficeNotice from './DeletedOfficeNotice';
+import { useSlowLoadingMessage } from '@/hooks/useSlowLoadingMessage';
 
 export default function LoginForm() {
   const [formData, setFormData] = useState({
@@ -19,6 +20,7 @@ export default function LoginForm() {
   const router = useRouter();
   const searchParams = useSearchParams();
   const messageShownRef = useRef(false); // メッセージ表示済みフラグ
+  const showSlowLoadingMessage = useSlowLoadingMessage(isLoading);
 
   // 自動認証チェックを削除: middlewareとDALパターンに委譲
   // これによりログインページでの不要な401エラーを防ぐ
@@ -199,10 +201,19 @@ export default function LoginForm() {
             <button
               type="submit"
               disabled={isLoading}
-              className="w-full bg-[#10B981] hover:bg-[#0F9F6E] text-white font-semibold py-3 px-4 rounded-lg transition-colors duration-200 shadow-lg hover:shadow-xl transform hover:-translate-y-0.5 disabled:opacity-50 disabled:cursor-not-allowed disabled:transform-none"
+              className="w-full bg-[#10B981] hover:bg-[#0F9F6E] text-white font-semibold py-3 px-4 rounded-lg transition-colors duration-200 shadow-lg hover:shadow-xl transform hover:-translate-y-0.5 disabled:opacity-50 disabled:cursor-not-allowed disabled:transform-none inline-flex items-center justify-center gap-2"
             >
+              {isLoading && (
+                <span className="h-4 w-4 animate-spin rounded-full border-2 border-white border-t-transparent" />
+              )}
               {isLoading ? 'ログイン中...' : 'ログイン'}
             </button>
+
+            {showSlowLoadingMessage && (
+              <p className="text-sm font-semibold text-slate-600 dark:text-gray-400">
+                読み込みに時間がかかっています。画面が変わらない場合は、通信状況を確認してページを更新してください。
+              </p>
+            )}
           </form>
 
           <div className="mt-6 text-center">

--- a/components/auth/SelectOffice.tsx
+++ b/components/auth/SelectOffice.tsx
@@ -27,7 +27,6 @@ export default function SelectOffice() {
       } catch (err) {
         const errorMessage = err instanceof Error ? err.message : '事業所の読み込みに失敗しました';
         setError(errorMessage);
-        console.log(errorMessage);
       } finally {
         setIsLoading(false);
       }

--- a/components/auth/SignupForm.tsx
+++ b/components/auth/SignupForm.tsx
@@ -7,6 +7,7 @@ import { authApi } from '@/lib/auth';
 import { StaffCreateData } from '@/types/staff';
 import TermsAgreement from '@/components/auth/TermsAgreement';
 import { validatePassword, ALLOWED_PASSWORD_SYMBOLS } from '@/lib/password-validation';
+import { useSlowLoadingMessage } from '@/hooks/useSlowLoadingMessage';
 
 export default function SignupForm() {
   const [formData, setFormData] = useState<StaffCreateData & { confirmPassword: string }> ({
@@ -25,6 +26,7 @@ export default function SignupForm() {
   const [termsAgreed, setTermsAgreed] = useState(false);
   const [privacyAgreed, setPrivacyAgreed] = useState(false);
   const router = useRouter();
+  const showSlowLoadingMessage = useSlowLoadingMessage(isLoading);
 
   const handleChange = (e: React.ChangeEvent<HTMLInputElement | HTMLSelectElement>) => {
     const { name, value } = e.target;
@@ -255,10 +257,19 @@ export default function SignupForm() {
             <button
               type="submit"
               disabled={isLoading || !termsAgreed || !privacyAgreed}
-              className="w-full bg-[#10B981] hover:bg-[#0F9F6E] text-white font-semibold py-3 px-4 rounded-lg transition-colors duration-200 shadow-lg hover:shadow-xl transform hover:-translate-y-0.5 disabled:opacity-50 disabled:cursor-not-allowed disabled:transform-none"
+              className="w-full bg-[#10B981] hover:bg-[#0F9F6E] text-white font-semibold py-3 px-4 rounded-lg transition-colors duration-200 shadow-lg hover:shadow-xl transform hover:-translate-y-0.5 disabled:opacity-50 disabled:cursor-not-allowed disabled:transform-none inline-flex items-center justify-center gap-2"
             >
+              {isLoading && (
+                <span className="h-4 w-4 animate-spin rounded-full border-2 border-white border-t-transparent" />
+              )}
               {isLoading ? '作成中...' : 'アカウントを作成する'}
             </button>
+
+            {showSlowLoadingMessage && (
+              <p className="text-sm font-semibold text-slate-600 dark:text-gray-400">
+                登録処理に時間がかかっています。画面が変わらない場合は、通信状況を確認してページを更新してください。
+              </p>
+            )}
           </form>
 
           <div className="mt-6 text-center">

--- a/components/auth/admin/SignupForm.tsx
+++ b/components/auth/admin/SignupForm.tsx
@@ -9,6 +9,7 @@ import StepWizard from '@/components/ui/StepWizard';
 import { authApi } from '@/lib/auth';
 import { AiOutlineEye, AiOutlineEyeInvisible } from 'react-icons/ai';
 import TermsAgreement from '@/components/auth/TermsAgreement';
+import { useSlowLoadingMessage } from '@/hooks/useSlowLoadingMessage';
 
 const signupSchema = z.object({
   last_name: z.string()
@@ -38,6 +39,7 @@ export default function AdminSignupForm() {
   const [termsAgreed, setTermsAgreed] = useState(false);
   const [privacyAgreed, setPrivacyAgreed] = useState(false);
   const router = useRouter();
+  const showSlowLoadingMessage = useSlowLoadingMessage(isLoading);
   
   const {
     register,
@@ -183,10 +185,19 @@ export default function AdminSignupForm() {
             <button
               type="submit"
               disabled={isLoading || !termsAgreed || !privacyAgreed}
-              className="w-full bg-[#10B981] hover:bg-[#0F9F6E] text-white font-semibold py-3 px-4 rounded-lg transition-colors duration-200 shadow-lg hover:shadow-xl transform hover:-translate-y-0.5 disabled:opacity-50 disabled:cursor-not-allowed disabled:transform-none"
+              className="w-full bg-[#10B981] hover:bg-[#0F9F6E] text-white font-semibold py-3 px-4 rounded-lg transition-colors duration-200 shadow-lg hover:shadow-xl transform hover:-translate-y-0.5 disabled:opacity-50 disabled:cursor-not-allowed disabled:transform-none inline-flex items-center justify-center gap-2"
             >
+              {isLoading && (
+                <span className="h-4 w-4 animate-spin rounded-full border-2 border-white border-t-transparent" />
+              )}
               {isLoading ? '作成中...' : 'アカウントを作成する'}
             </button>
+
+            {showSlowLoadingMessage && (
+              <p className="text-sm font-semibold text-slate-600 dark:text-gray-400">
+                登録処理に時間がかかっています。画面が変わらない場合は、通信状況を確認してページを更新してください。
+              </p>
+            )}
           </form>
 
           <div className="mt-6 text-center">

--- a/components/protected/LayoutClient.tsx
+++ b/components/protected/LayoutClient.tsx
@@ -58,6 +58,7 @@ export default function ProtectedLayoutClient({ children, user }: ProtectedLayou
   const [isMenuOpen, setIsMenuOpen] = useState<boolean>(false);
   const [showOfficeTooltip, setShowOfficeTooltip] = useState<boolean>(false);
   const longPressTimerRef = useRef<NodeJS.Timeout | null>(null);
+  const unreadCountIntervalRef = useRef<number | null>(null);
   const deadlineAlertsShownRef = useRef<boolean>(false);
   const deadlineAlertsSessionKey = 'keikakun_deadline_alerts_toast_shown';
 
@@ -181,9 +182,6 @@ export default function ProtectedLayoutClient({ children, user }: ProtectedLayou
         });
     }
 
-    // 初回の未読件数取得
-    fetchUnreadCount();
-
     // 通知設定を取得し、トースト表示とPush購読を実行（ログイン時のみ、1回だけ）
     const initializeNotifications = async () => {
       try {
@@ -232,15 +230,26 @@ export default function ProtectedLayoutClient({ children, user }: ProtectedLayou
       }
     };
 
-    initializeNotifications();
-
-    // 30秒ごとに未読件数を更新
-    const interval = setInterval(() => {
+    const notificationInitTimer = window.setTimeout(() => {
       fetchUnreadCount();
-    }, 30000); // 30秒
+      initializeNotifications();
+    }, 1200);
+
+    // 初期描画後に30秒ごとの未読件数更新を開始
+    const intervalStartTimer = window.setTimeout(() => {
+      const interval = window.setInterval(() => {
+        fetchUnreadCount();
+      }, 30000);
+      unreadCountIntervalRef.current = interval;
+    }, 1200);
 
     return () => {
-      clearInterval(interval);
+      window.clearTimeout(notificationInitTimer);
+      window.clearTimeout(intervalStartTimer);
+      if (unreadCountIntervalRef.current) {
+        window.clearInterval(unreadCountIntervalRef.current);
+        unreadCountIntervalRef.current = null;
+      }
     };
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);

--- a/components/protected/LayoutClient.tsx
+++ b/components/protected/LayoutClient.tsx
@@ -225,7 +225,6 @@ export default function ProtectedLayoutClient({ children, user }: ProtectedLayou
           !(isIOS && !isPWA)
         ) {
           await subscribe();
-          console.log('[Auto-subscribe] Push notification subscribed on login');
         }
       } catch (error) {
         console.error('[Notifications] Failed to initialize notifications:', error);

--- a/components/protected/app-admin/InquiryReplyModal.tsx
+++ b/components/protected/app-admin/InquiryReplyModal.tsx
@@ -38,7 +38,6 @@ export default function InquiryReplyModal({
         send_email: sendEmail,
       });
 
-      console.log('✅ [InquiryReplyModal] 返信送信成功:', response.message);
       toast.success(response.message || '返信を送信しました');
 
       // 成功時にコールバックを実行してモーダルを閉じる

--- a/components/protected/dashboard/Dashboard.tsx
+++ b/components/protected/dashboard/Dashboard.tsx
@@ -225,9 +225,7 @@ export default function Dashboard() {
         ...params,
       };
 
-      console.log('Applying filters with params:', filterParams);
       const newDashboardData = await dashboardApi.getDashboardData(filterParams);
-      console.log('API Response:', newDashboardData);
 
       // recipients を必ず配列にする（API の不整合や null を防ぐ）
       if (newDashboardData) {

--- a/components/protected/profile/Profile.tsx
+++ b/components/protected/profile/Profile.tsx
@@ -120,14 +120,10 @@ export default function Profile({ staff: initialStaff }: ProfileProps) {
       });
 
       setIsEditingName(false);
-      console.log('🎉 [Profile] 名前更新成功 - toastを表示します');
       toast.success('名前を更新しました');
-      console.log('🎉 [Profile] toast.success呼び出し完了');
     } catch (err: unknown) {
       const message = err instanceof Error ? err.message : String(err);
-      console.error('❌ [Profile] 名前更新失敗:', message);
       toast.error(message || '名前の更新に失敗しました');
-      console.log('❌ [Profile] toast.error呼び出し完了');
     } finally {
       setIsLoading(false);
     }
@@ -160,9 +156,7 @@ export default function Profile({ staff: initialStaff }: ProfileProps) {
       setNewPassword('');
       setNewPasswordConfirm('');
 
-      console.log('🔐 [Profile] パスワード変更成功 - toastを表示します:', response.message);
       toast.success(response.message);
-      console.log('🔐 [Profile] toast.success呼び出し完了');
 
       // パスワード変更後はログアウトされるため、ログインページにリダイレクト
       setTimeout(() => {
@@ -170,9 +164,7 @@ export default function Profile({ staff: initialStaff }: ProfileProps) {
       }, 2000);
     } catch (err: unknown) {
       const message = err instanceof Error ? err.message : String(err);
-      console.error('❌ [Profile] パスワード変更失敗:', message);
       toast.error(message || 'パスワードの変更に失敗しました');
-      console.log('❌ [Profile] toast.error呼び出し完了');
     } finally {
       setIsLoading(false);
     }
@@ -223,9 +215,7 @@ export default function Profile({ staff: initialStaff }: ProfileProps) {
       setEmailModalError(null);
 
       const message = `確認メールを ${newEmail} に送信しました。メール内のリンクをクリックして変更を完了してください。`;
-      console.log('📧 [Profile] メールアドレス変更リクエスト成功 - toastを表示します:', message);
       toast.success(message, { duration: 10000 });
-      console.log('📧 [Profile] toast.success呼び出し完了');
     } catch (err: unknown) {
       // サーバーエラーをモーダル内に表示
       const message = err instanceof Error ? err.message : String(err);
@@ -239,16 +229,12 @@ export default function Profile({ staff: initialStaff }: ProfileProps) {
   const handleFeedbackSubmit = async () => {
     // バリデーション
     if (!feedbackTitle.trim()) {
-      console.log('⚠️ [Profile] フィードバック件名が空 - エラーtoastを表示します');
       toast.error('件名を入力してください');
-      console.log('⚠️ [Profile] toast.error呼び出し完了');
       return;
     }
 
     if (!feedbackContent.trim()) {
-      console.log('⚠️ [Profile] フィードバック内容が空 - エラーtoastを表示します');
       toast.error('フィードバック内容を入力してください');
-      console.log('⚠️ [Profile] toast.error呼び出し完了');
       return;
     }
 
@@ -262,19 +248,15 @@ export default function Profile({ staff: initialStaff }: ProfileProps) {
         category: feedbackCategory,
       });
 
-      console.log('📬 [Profile] フィードバック送信成功 - toastを表示します:', response.message);
       toast.success(response.message || 'フィードバックを送信しました。ご協力ありがとうございます。');
-      console.log('📬 [Profile] toast.success呼び出し完了');
 
       // フォームをクリア
       setFeedbackTitle('');
       setFeedbackContent('');
       setFeedbackCategory('その他');
     } catch (error) {
-      console.error('❌ [Profile] フィードバック送信失敗:', error);
       const message = error instanceof Error ? error.message : String(error);
       toast.error(message || 'フィードバックの送信に失敗しました。しばらく時間をおいてからお試しください。');
-      console.log('❌ [Profile] toast.error呼び出し完了');
     } finally {
       setIsLoading(false);
     }

--- a/components/protected/profile/RequestCard.tsx
+++ b/components/protected/profile/RequestCard.tsx
@@ -34,13 +34,6 @@ const resourceTypeLabels: Record<ResourceType, string> = {
 };
 
 export default function RequestCard({ request, type, onDelete }: RequestCardProps) {
-  console.log('[DEBUG REQUEST_CARD] Rendering card for request:', {
-    type,
-    id: request.id,
-    status: request.status,
-    request,
-  });
-
   // ステータスに応じたスタイルとアイコン
   const getStatusStyle = (status: RequestStatus) => {
     switch (status) {

--- a/components/protected/profile/SentRequestsTab.tsx
+++ b/components/protected/profile/SentRequestsTab.tsx
@@ -22,23 +22,15 @@ export default function SentRequestsTab() {
     setIsLoading(true);
     setError(null);
     try {
-      console.log('[DEBUG SENT_REQUESTS_TAB] Loading requests with filter:', filter);
-
       // Role変更リクエストとEmployee制限リクエストを並行で取得
       const [roleChangeData, employeeActionData] = await Promise.all([
         roleChangeRequestsApi.getRequests().catch(() => ({ requests: [], total: 0 })),
         employeeActionRequestsApi.getRequests().catch(() => ({ requests: [], total: 0 })),
       ]);
 
-      console.log('[DEBUG SENT_REQUESTS_TAB] Role change data:', roleChangeData);
-      console.log('[DEBUG SENT_REQUESTS_TAB] Employee action data:', employeeActionData);
-
       // 安全にrequests配列にアクセス（undefinedの場合は空配列を使用）
       const roleChangeRequests = roleChangeData?.requests || [];
       const employeeActionRequests = employeeActionData?.requests || [];
-
-      console.log('[DEBUG SENT_REQUESTS_TAB] Role change requests count:', roleChangeRequests.length);
-      console.log('[DEBUG SENT_REQUESTS_TAB] Employee action requests count:', employeeActionRequests.length);
 
       // 両方のリクエストを結合して、作成日時でソート
       const combined: CombinedRequest[] = [
@@ -56,8 +48,6 @@ export default function SentRequestsTab() {
         return dateB - dateA; // 新しい順
       });
 
-      console.log('[DEBUG SENT_REQUESTS_TAB] Combined requests:', combined);
-
       // フィルターを適用
       const filtered = combined.filter((item) => {
         if (filter === 'pending') {
@@ -72,13 +62,10 @@ export default function SentRequestsTab() {
         return true; // 'all'
       });
 
-      console.log('[DEBUG SENT_REQUESTS_TAB] Filtered requests:', filtered);
-      console.log('[DEBUG SENT_REQUESTS_TAB] Setting requests to state, count:', filtered.length);
-
       setRequests(filtered);
     } catch (err: unknown) {
       const message = err instanceof Error ? err.message : String(err);
-      console.error('[DEBUG SENT_REQUESTS_TAB] Error loading requests:', err);
+      console.error('リクエストの取得に失敗しました');
       setError(message || 'リクエストの取得に失敗しました');
       // エラー時も空配列を設定
       setRequests([]);

--- a/components/protected/support_plan/SupportPlan.tsx
+++ b/components/protected/support_plan/SupportPlan.tsx
@@ -33,9 +33,6 @@ export default function SupportPlan() {
     const fetchData = async () => {
       if (!recipientId) return;
 
-      console.log('=== SupportPlan useEffect ===');
-      console.log('recipientId:', recipientId);
-
       try {
         setIsLoading(true);
         setError(null);
@@ -45,9 +42,6 @@ export default function SupportPlan() {
           welfareRecipientsApi.get(recipientId),
           supportPlanApi.getCycles(recipientId),
         ]);
-
-        console.log('recipientData:', recipientData);
-        console.log('cyclesData:', cyclesData);
 
         setRecipient(recipientData);
         setCycles(cyclesData.cycles || []);
@@ -112,10 +106,6 @@ export default function SupportPlan() {
   };
 
   const handleCellClick = (cycle: PlanCycle, stepType: string) => {
-    console.log('=== handleCellClick ===');
-    console.log('cycle:', cycle);
-    console.log('stepType (passed):', stepType);
-    console.log('cycle_number:', cycle.cycle_number);
     setSelectedCycle(cycle);
     setSelectedStepType(stepType);
     setIsModalOpen(true);
@@ -124,20 +114,13 @@ export default function SupportPlan() {
   const handleUpload = async (file: File) => {
     if (!selectedCycle) return;
 
-    console.log('=== handleUpload START ===');
-    console.log('recipientId:', recipientId);
-    console.log('cycleId:', selectedCycle.id);
-    console.log('stepType:', selectedStepType);
-    console.log('file:', file.name, file.type, file.size);
-
     try {
-      const result = await supportPlanApi.uploadDeliverable(
+      await supportPlanApi.uploadDeliverable(
         recipientId,
         selectedCycle.id,
         selectedStepType,
         file
       );
-      console.log('Upload success:', result);
 
       // アップロード成功後、データを再取得
       const cyclesData = await supportPlanApi.getCycles(recipientId);
@@ -149,10 +132,6 @@ export default function SupportPlan() {
       setIsModalOpen(false);
     } catch (err) {
       console.error('Failed to upload file:', err);
-      console.error('Error details:', {
-        message: err instanceof Error ? err.message : 'Unknown error',
-        stack: err instanceof Error ? err.stack : undefined
-      });
       // エラーメッセージを表示
       toast.error('PDFのアップロードに失敗しました');
       throw err; // モーダル側でエラーハンドリング

--- a/hooks/usePushNotification.ts
+++ b/hooks/usePushNotification.ts
@@ -172,7 +172,6 @@ export function usePushNotification(): UsePushNotificationReturn {
       );
 
       setIsSubscribed(true);
-      console.log('[usePushNotification] Successfully subscribed');
     } catch (err) {
       console.error('[usePushNotification] Subscribe error:', err);
       const errorMessage = err instanceof Error ? err.message : 'UNKNOWN_ERROR';
@@ -192,7 +191,6 @@ export function usePushNotification(): UsePushNotificationReturn {
 
       if (!registration) {
         // Service Workerが登録されていない場合は、既に購読解除済みとみなす
-        console.log('[usePushNotification] Service Worker not registered, assuming already unsubscribed');
         setIsSubscribed(false);
         return;
       }
@@ -201,7 +199,6 @@ export function usePushNotification(): UsePushNotificationReturn {
 
       if (!subscription) {
         // 購読が存在しない場合は、既に購読解除済みとみなす
-        console.log('[usePushNotification] No subscription found, assuming already unsubscribed');
         setIsSubscribed(false);
         return;
       }
@@ -222,7 +219,6 @@ export function usePushNotification(): UsePushNotificationReturn {
       }
 
       setIsSubscribed(false);
-      console.log('[usePushNotification] Successfully unsubscribed');
     } catch (err) {
       console.error('[usePushNotification] Unsubscribe error:', err);
       const errorMessage = err instanceof Error ? err.message : 'UNKNOWN_ERROR';

--- a/hooks/useSlowLoadingMessage.ts
+++ b/hooks/useSlowLoadingMessage.ts
@@ -1,0 +1,28 @@
+import { useEffect, useState } from 'react';
+
+export function useSlowLoadingMessage(isLoading: boolean, delayMs = 5000) {
+  const [showMessage, setShowMessage] = useState(false);
+
+  useEffect(() => {
+    if (!isLoading) {
+      const resetTimer = window.setTimeout(() => {
+        setShowMessage(false);
+      }, 0);
+      return () => window.clearTimeout(resetTimer);
+    }
+
+    const resetTimer = window.setTimeout(() => {
+      setShowMessage(false);
+    }, 0);
+    const timer = window.setTimeout(() => {
+      setShowMessage(true);
+    }, delayMs);
+
+    return () => {
+      window.clearTimeout(resetTimer);
+      window.clearTimeout(timer);
+    };
+  }, [delayMs, isLoading]);
+
+  return showMessage;
+}

--- a/lib/api/employeeActionRequests.ts
+++ b/lib/api/employeeActionRequests.ts
@@ -43,22 +43,7 @@ export const employeeActionRequestsApi = {
       ? `${API_V1_PREFIX}/employee-action-requests?${queryString}`
       : `${API_V1_PREFIX}/employee-action-requests`;
 
-    console.log('[DEBUG FRONTEND] Fetching employee action requests:', endpoint);
-    const response = await http.get<EmployeeActionRequestListResponse>(endpoint);
-    console.log('[DEBUG FRONTEND] Employee action requests response:', response);
-    console.log('[DEBUG FRONTEND] Requests count:', response?.requests?.length || 0);
-    if (response?.requests) {
-      response.requests.forEach((req, index) => {
-        console.log(`[DEBUG FRONTEND] Request ${index + 1}:`, {
-          id: req.id,
-          resource_type: req.resource_type,
-          action_type: req.action_type,
-          status: req.status,
-          request_data: req.request_data,
-        });
-      });
-    }
-    return response;
+    return http.get<EmployeeActionRequestListResponse>(endpoint);
   },
 
   /**

--- a/lib/api/roleChangeRequests.ts
+++ b/lib/api/roleChangeRequests.ts
@@ -39,22 +39,7 @@ export const roleChangeRequestsApi = {
       ? `${API_V1_PREFIX}/role-change-requests?${queryString}`
       : `${API_V1_PREFIX}/role-change-requests`;
 
-    console.log('[DEBUG FRONTEND] Fetching role change requests:', endpoint);
-    const response = await http.get<RoleChangeRequestListResponse>(endpoint);
-    console.log('[DEBUG FRONTEND] Role change requests response:', response);
-    console.log('[DEBUG FRONTEND] Requests count:', response?.requests?.length || 0);
-    if (response?.requests) {
-      response.requests.forEach((req, index) => {
-        console.log(`[DEBUG FRONTEND] Request ${index + 1}:`, {
-          id: req.id,
-          from_role: req.from_role,
-          requested_role: req.requested_role,
-          status: req.status,
-          request_notes: req.request_notes,
-        });
-      });
-    }
-    return response;
+    return http.get<RoleChangeRequestListResponse>(endpoint);
   },
 
   /**

--- a/lib/csrf.ts
+++ b/lib/csrf.ts
@@ -21,10 +21,9 @@ export const initializeCsrfToken = async (): Promise<boolean> => {
   try {
     const token = await csrfApi.getCsrfToken();
     setCsrfToken(token);
-    console.log('[CSRF] Token initialized successfully');
     return true;
-  } catch (error) {
-    console.error('[CSRF] Failed to initialize CSRF token:', error);
+  } catch {
+    console.error('[CSRF] Failed to initialize CSRF token');
     return false;
   }
 };
@@ -37,6 +36,5 @@ export const initializeCsrfToken = async (): Promise<boolean> => {
  * @returns リフレッシュが成功したかどうか
  */
 export const refreshCsrfToken = async (): Promise<boolean> => {
-  console.log('[CSRF] Refreshing CSRF token...');
   return await initializeCsrfToken();
 };

--- a/lib/http.ts
+++ b/lib/http.ts
@@ -138,8 +138,6 @@ async function request<T>(endpoint: string, options: RequestInit = {}): Promise<
 
   // Cookie認証: credentials: 'include' により自動的にCookieが送信される
   // バックエンドはCookieから認証情報を取得する
-  // console.log('[DEBUG HTTP] Request URL:', url);
-  // console.log('[DEBUG HTTP] Environment:', typeof window === 'undefined' ? 'server' : 'client');
 
   const defaultHeaders: HeadersInit = {
     'Content-Type': 'application/json',
@@ -162,24 +160,17 @@ async function request<T>(endpoint: string, options: RequestInit = {}): Promise<
     },
   };
 
-  // console.log('[DEBUG HTTP] Request config:', { method: config.method || 'GET', headers: config.headers });
-
   const response = await fetch(url, config);
-  // console.log('[DEBUG HTTP] Response status:', response.status, response.statusText);
 
   if (!response.ok) {
-    console.error('[DEBUG HTTP] Response not OK. Status:', response.status);
     if (response.status === 401) {
       // 認証エラーの場合はログアウト処理
-      console.error('[DEBUG HTTP] 401 Unauthorized - triggering logout');
       await handleLogout();
       // エラーを投げて処理を中断
       throw new Error('認証されていません');
     }
     const errorData = await response.json().catch(() => ({ detail: `リクエストが失敗しました (ステータス: ${response.status})` }));
-    console.error('[DEBUG HTTP] Error data:', errorData);
     const errorMessage = formatErrorMessage(errorData);
-    console.error('[DEBUG HTTP] Formatted error message:', errorMessage);
     throw new Error(errorMessage);
   }
 

--- a/lib/pdf-deliverables.ts
+++ b/lib/pdf-deliverables.ts
@@ -9,8 +9,6 @@ export const pdfDeliverablesApi = {
    * PDF一覧を取得
    */
   async getList(params: PlanDeliverableSearchParams): Promise<PlanDeliverableListResponse> {
-    console.log('[DEBUG] pdfDeliverablesApi.getList called with params:', params);
-
     const searchParams = new URLSearchParams();
 
     // 必須パラメータ
@@ -28,11 +26,7 @@ export const pdfDeliverablesApi = {
     if (params.limit !== undefined) searchParams.append('limit', params.limit.toString());
 
     const endpoint = `/api/v1/support-plans/plan-deliverables?${searchParams.toString()}`;
-    console.log('[DEBUG] Requesting endpoint:', endpoint);
-
-    const response = await http.get<PlanDeliverableListResponse>(endpoint);
-    console.log('[DEBUG] Response received:', response);
-    return response;
+    return http.get<PlanDeliverableListResponse>(endpoint);
   },
 
   /**

--- a/lib/support-plan.ts
+++ b/lib/support-plan.ts
@@ -50,14 +50,6 @@ export const supportPlanApi = {
   ): Promise<{ success: boolean; message: string }> => {
     const deliverableType = STEP_TO_DELIVERABLE_MAP[stepType] || stepType;
 
-    console.log('=== uploadDeliverable API Call ===');
-    console.log('recipientId:', recipientId);
-    console.log('cycleId:', cycleId);
-    console.log('stepType (from UI):', stepType);
-    console.log('deliverableType (mapped):', deliverableType);
-    console.log('file:', file.name, file.type, file.size);
-    console.log('STEP_TO_DELIVERABLE_MAP:', STEP_TO_DELIVERABLE_MAP);
-
     const formData = new FormData();
     formData.append('file', file);
     formData.append('plan_cycle_id', cycleId);
@@ -65,31 +57,17 @@ export const supportPlanApi = {
 
     const API_BASE_URL = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:8000';
 
-    console.log('API URL:', `${API_BASE_URL}/api/v1/support-plans/plan-deliverables`);
-
     // Cookieで認証されるため、credentials: 'include'を追加
     return fetch(`${API_BASE_URL}/api/v1/support-plans/plan-deliverables`, {
       method: 'POST',
       credentials: 'include', // Cookie自動送信
       body: formData,
     }).then(async (res) => {
-      console.log('Response status:', res.status, res.statusText);
-
       if (!res.ok) {
-        const errorText = await res.text();
-        console.error('Response error body:', errorText);
-        try {
-          const errorJson = JSON.parse(errorText);
-          console.error('Parsed error:', errorJson);
-        } catch {
-          console.error('Could not parse error as JSON');
-        }
         throw new Error(`アップロードに失敗しました: ${res.status} ${res.statusText}`);
       }
 
-      const responseData = await res.json();
-      console.log('Response data:', responseData);
-      return responseData;
+      return res.json();
     });
   },
 

--- a/public/sw.js
+++ b/public/sw.js
@@ -1,26 +1,20 @@
 const SW_VERSION = 'v2.0.0';
 
 self.addEventListener('install', () => {
-  console.log(`[Service Worker ${SW_VERSION}] Install event`);
   self.skipWaiting();
 });
 
 self.addEventListener('activate', (event) => {
-  console.log(`[Service Worker ${SW_VERSION}] Activate event`);
   event.waitUntil(self.clients.claim());
 });
 
 self.addEventListener('push', (event) => {
-  console.log(`[Service Worker ${SW_VERSION}] Push event received`);
-
   if (!event.data) {
-    console.log(`[Service Worker ${SW_VERSION}] Push event has no data`);
     return;
   }
 
   try {
     const data = event.data.json();
-    console.log(`[Service Worker ${SW_VERSION}] Push data:`, data);
 
     const options = {
       body: data.body || '',
@@ -37,16 +31,10 @@ self.addEventListener('push', (event) => {
       timestamp: Date.now()
     };
 
-    console.log(`[Service Worker ${SW_VERSION}] Showing notification with options:`, options);
-    console.log(`[Service Worker ${SW_VERSION}] Notification.permission:`, Notification.permission);
-
     event.waitUntil(
       self.registration.showNotification(data.title || '通知', options)
-        .then(() => {
-          console.log(`[Service Worker ${SW_VERSION}] ✅ Notification shown successfully`);
-        })
         .catch((error) => {
-          console.error(`[Service Worker ${SW_VERSION}] ❌ Failed to show notification:`, error);
+          console.error(`[Service Worker ${SW_VERSION}] Failed to show notification:`, error);
         })
     );
   } catch (error) {
@@ -55,8 +43,6 @@ self.addEventListener('push', (event) => {
 });
 
 self.addEventListener('notificationclick', (event) => {
-  console.log(`[Service Worker ${SW_VERSION}] Notification click event`);
-
   event.notification.close();
 
   const data = event.notification.data || {};
@@ -98,15 +84,12 @@ self.addEventListener('notificationclick', (event) => {
 });
 
 self.addEventListener('pushsubscriptionchange', (event) => {
-  console.log(`[Service Worker ${SW_VERSION}] Push subscription changed`);
-
   event.waitUntil(
     self.registration.pushManager.subscribe({
       userVisibleOnly: true,
       applicationServerKey: null
     })
     .then((subscription) => {
-      console.log(`[Service Worker ${SW_VERSION}] Re-subscribed:`, subscription);
       return fetch('/api/v1/push-subscriptions/subscribe', {
         method: 'POST',
         headers: {


### PR DESCRIPTION
## Summary
- Remove frontend debug console output from production-facing code paths.
- Add delayed loading feedback and spinner affordances to login, signup, admin signup, and MFA verification flows.
- Delay initial notification/unread-count work slightly after protected layout mount.

## Validation
- npm run lint