### PR TITLE
refactor: split maintainability-heavy frontend components

### DIFF
--- a/components/admin/inquiry/InquiryDetail.tsx
+++ b/components/admin/inquiry/InquiryDetail.tsx
@@ -49,7 +49,7 @@ export default function InquiryDetail({ inquiryId, onBack, onOpenReply }: Inquir
         },
       });
     } catch (err) {
-      console.error('ステータスの更新に失敗しました:', err);
+      console.error('Client operation failed');
     } finally {
       setIsUpdating(false);
     }
@@ -69,7 +69,7 @@ export default function InquiryDetail({ inquiryId, onBack, onOpenReply }: Inquir
         },
       });
     } catch (err) {
-      console.error('優先度の更新に失敗しました:', err);
+      console.error('Client operation failed');
     } finally {
       setIsUpdating(false);
     }

--- a/components/admin/inquiry/InquiryReplyModal.tsx
+++ b/components/admin/inquiry/InquiryReplyModal.tsx
@@ -55,7 +55,7 @@ export default function InquiryReplyModal({
         onSuccess();
       }
     } catch (err) {
-      console.error('返信の送信に失敗しました:', err);
+      console.error('Client operation failed');
       setError('返信の送信に失敗しました。もう一度お試しください。');
     } finally {
       setIsSubmitting(false);

--- a/components/auth/admin/LoginForm.tsx
+++ b/components/auth/admin/LoginForm.tsx
@@ -50,8 +50,8 @@ export default function AdminLoginForm() {
       try {
         await authApi.getCurrentUser();
         router.push('/auth/admin/office_setup');
-      } catch (verifyError) {
-        console.error('Cookie verification failed:', verifyError);
+      } catch {
+        console.error('Cookie verification failed');
         setFormError('root', { message: '認証に失敗しました。もう一度お試しください。' });
       }
     } catch (error: unknown) {

--- a/components/auth/app-admin/LoginForm.tsx
+++ b/components/auth/app-admin/LoginForm.tsx
@@ -64,8 +64,8 @@ export default function AppAdminLoginForm() {
         }
 
         router.push('/app-admin');
-      } catch (verifyError) {
-        console.error('User verification failed:', verifyError);
+      } catch {
+        console.error('User verification failed');
         setFormError('root', { message: '認証に失敗しました。もう一度お試しください。' });
       }
     } catch (error: unknown) {

--- a/components/billing/PastDueModal.tsx
+++ b/components/billing/PastDueModal.tsx
@@ -91,7 +91,7 @@ export default function PastDueModal({ isOpen, onClose }: PastDueModalProps) {
 
       window.location.href = '/admin?tab=plan';
     } catch (err) {
-      console.error('課金アクションの開始に失敗しました:', err);
+      console.error('Client operation failed');
       setError(err instanceof Error ? err.message : '課金アクションの開始に失敗しました');
     } finally {
       setIsLoading(false);

--- a/components/common/EmployeeActionRequestModal.tsx
+++ b/components/common/EmployeeActionRequestModal.tsx
@@ -58,7 +58,7 @@ export default function EmployeeActionRequestModal({
       onClose();
       setNotes('');
     } catch (err) {
-      console.error('Failed to create employee action request:', err);
+      console.error('Client operation failed');
       if (err instanceof Error) {
         setError(err.message);
       } else {

--- a/components/inquiry/InquiryModal.tsx
+++ b/components/inquiry/InquiryModal.tsx
@@ -65,7 +65,7 @@ export default function InquiryModal({ isOpen, onClose }: InquiryModalProps) {
         handleClose();
       }, 2000);
     } catch (error) {
-      console.error('問い合わせの送信に失敗しました:', error);
+      console.error('Client operation failed');
       setErrors({ submit: '送信に失敗しました。もう一度お試しください。' });
     } finally {
       setIsSubmitting(false);

--- a/components/inquiry/InquirySendForm.tsx
+++ b/components/inquiry/InquirySendForm.tsx
@@ -55,7 +55,7 @@ export default function InquirySendForm() {
         setSubmitSuccess(false);
       }, 3000);
     } catch (error) {
-      console.error('問い合わせの送信に失敗しました:', error);
+      console.error('Client operation failed');
       setErrors({ submit: '送信に失敗しました。もう一度お試しください。' });
     } finally {
       setIsSubmitting(false);

--- a/components/notice/DeadlineAlertsTab.tsx
+++ b/components/notice/DeadlineAlertsTab.tsx
@@ -43,7 +43,7 @@ export default function DeadlineAlertsTab() {
         setAlerts(data.alerts);
         setTotal(data.total);
       } catch (err) {
-        console.error('更新期限のお知らせの取得に失敗しました:', err);
+        console.error('Client operation failed');
         setError('更新期限のお知らせの取得に失敗しました。時間をおいて再度お試しください。');
       } finally {
         setIsLoading(false);

--- a/components/protected/LayoutClient.tsx
+++ b/components/protected/LayoutClient.tsx
@@ -74,7 +74,7 @@ export default function ProtectedLayoutClient({ children, user }: ProtectedLayou
       const totalUnread = noticesData.unread_count + messagesData.unread_count;
       setUnreadCount(totalUnread);
     } catch (error) {
-      console.error('未読通知件数の取得に失敗しました', error);
+      console.error('Client operation failed');
     }
   };
 
@@ -87,7 +87,7 @@ export default function ProtectedLayoutClient({ children, user }: ProtectedLayou
       setRecentUnreadMessages(data.messages.slice(0, 3));
       setMessagesLoaded(true);
     } catch (error) {
-      console.error('未読メッセージの取得に失敗しました', error);
+      console.error('Client operation failed');
     }
   };
 
@@ -97,7 +97,7 @@ export default function ProtectedLayoutClient({ children, user }: ProtectedLayou
       const data = await deadlineApi.getAlerts({ threshold_days: 30 });
       return data.alerts;
     } catch (error) {
-      console.error('更新期限のお知らせの取得に失敗しました', error);
+      console.error('Client operation failed');
       return null;
     }
   };
@@ -141,7 +141,7 @@ export default function ProtectedLayoutClient({ children, user }: ProtectedLayou
       setTotalDeadlineAlerts(data.total);
       setDeadlineAlertsOffset(offset + data.alerts.length);
     } catch (error) {
-      console.error('更新期限のお知らせの取得に失敗しました', error);
+      console.error('Client operation failed');
     }
   };
 
@@ -169,7 +169,7 @@ export default function ProtectedLayoutClient({ children, user }: ProtectedLayou
 
     // CSRFトークンを初期化（ページリフレッシュ時に必要）
     initializeCsrfToken().catch(error => {
-      console.error('CSRFトークンの初期化に失敗しました', error);
+      console.error('Client operation failed');
     });
 
     // 事業所情報が未取得の場合のみ取得
@@ -177,7 +177,7 @@ export default function ProtectedLayoutClient({ children, user }: ProtectedLayou
       officeApi.getMyOffice()
         .then(officeData => setOffice(officeData))
         .catch(error => {
-          console.error('事業所情報の取得に失敗しました', error);
+          console.error('Client operation failed');
         });
     }
 
@@ -227,7 +227,7 @@ export default function ProtectedLayoutClient({ children, user }: ProtectedLayou
           await subscribe();
         }
       } catch (error) {
-        console.error('[Notifications] Failed to initialize notifications:', error);
+        console.error('Client operation failed');
         // エラー時も処理を継続（ユーザー体験に影響を与えない）
       }
     };
@@ -274,7 +274,7 @@ export default function ProtectedLayoutClient({ children, user }: ProtectedLayou
       // これにより、Cookie削除が確実に反映された状態でログインページが読み込まれる
       window.location.href = `/auth/login?${params.toString()}`;
     } catch (error) {
-      console.error('Logout failed:', error);
+      console.error('Client operation failed');
       // エラーが発生してもログイン画面にリダイレクト
       window.location.href = '/auth/login';
     }

--- a/components/protected/admin/AdminMenu.tsx
+++ b/components/protected/admin/AdminMenu.tsx
@@ -2,8 +2,6 @@
 
 import { useState, useEffect } from 'react';
 import { useSearchParams } from 'next/navigation';
-import { MdEdit, MdCheckCircle, MdCancel, MdDelete, MdExitToApp } from 'react-icons/md';
-import { AiOutlineQuestionCircle } from 'react-icons/ai';
 import { QRCodeCanvas } from 'qrcode.react';
 import { StaffResponse } from '@/types/staff';
 import { OfficeResponse, OfficeInfoUpdateRequest, OfficeTypeValue } from '@/types/office';
@@ -12,7 +10,11 @@ import { OfficeCalendarAccount, CalendarConnectionStatus } from '@/types/calenda
 import { authApi, officeApi } from '@/lib/auth';
 import { officesApi } from '@/lib/api/offices';
 import WithdrawalModal from './WithdrawalModal';
-import PlanTab from './PlanTab';
+import BillingPlanTab from './BillingPlanTab';
+import OfficeInfoTab from './OfficeInfoTab';
+import StaffManagementTab from './StaffManagementTab';
+import GoogleIntegrationTab from './GoogleIntegrationTab';
+import OfficeEditModal from './OfficeEditModal';
 
 interface AdminMenuProps {
   office: OfficeResponse | null;
@@ -605,14 +607,12 @@ export default function AdminMenu({ office }: AdminMenuProps) {
             <div>
               <h2 className="text-2xl font-bold mb-4">事業所設定</h2>
 
-              {/* ２段階認証成功メッセージ */}
               {mfaSuccess && (
                 <div className="mb-4 p-4 bg-green-900/50 border border-green-500 rounded-lg">
                   <p className="text-green-400 text-base">{mfaSuccess}</p>
                 </div>
               )}
 
-              {/* ２段階認証エラーメッセージ */}
               {mfaError && (
                 <div className="mb-4 p-4 bg-red-900/50 border border-red-500 rounded-lg">
                   <p className="text-red-400 text-base font-semibold">エラー</p>
@@ -620,14 +620,12 @@ export default function AdminMenu({ office }: AdminMenuProps) {
                 </div>
               )}
 
-              {/* スタッフ削除成功メッセージ */}
               {deleteStaffSuccess && (
                 <div className="mb-4 p-4 bg-green-900/50 border border-green-500 rounded-lg">
                   <p className="text-green-400 text-base">{deleteStaffSuccess}</p>
                 </div>
               )}
 
-              {/* スタッフ削除エラーメッセージ */}
               {deleteStaffError && (
                 <div className="mb-4 p-4 bg-red-900/50 border border-red-500 rounded-lg">
                   <p className="text-red-400 text-base font-semibold">エラー</p>
@@ -635,600 +633,62 @@ export default function AdminMenu({ office }: AdminMenuProps) {
                 </div>
               )}
 
-              {/* オフィス情報カード */}
-              <div className="bg-white p-6 rounded-lg mb-6 border border-slate-300 shadow-sm dark:bg-gray-800 dark:border-gray-700">
-                <div className="flex items-center justify-between mb-4">
-                  <h3 className="text-xl font-semibold">事業所情報</h3>
-                  <button
-                    onClick={handleOpenOfficeEditModal}
-                    className="flex items-center gap-2 bg-blue-600 hover:bg-blue-700 text-white px-4 py-2 rounded-lg transition-colors"
-                  >
-                    <MdEdit className="w-5 h-5" />
-                    編集
-                  </button>
-                </div>
-                <div className="space-y-3">
-                  <div>
-                    <p className="text-slate-600 text-base font-semibold dark:text-gray-400">事業所名</p>
-                    <p className="text-slate-900 font-semibold dark:text-white">{office?.name || '未設定'}</p>
-                  </div>
-                  <div>
-                    <p className="text-slate-600 text-base font-semibold dark:text-gray-400">事業所種別</p>
-                    <p className="text-slate-900 font-semibold dark:text-white">
-                      {office?.office_type === 'transition_to_employment' && '移行支援'}
-                      {office?.office_type === 'type_A_office' && '就労A型'}
-                      {office?.office_type === 'type_B_office' && '就労B型'}
-                      {!office?.office_type && '未設定'}
-                    </p>
-                  </div>
-                  <div>
-                    <p className="text-slate-600 text-base font-semibold dark:text-gray-400">住所</p>
-                    <p className="text-slate-900 font-semibold dark:text-white">{office?.address || '未設定'}</p>
-                  </div>
-                  <div>
-                    <p className="text-slate-600 text-base font-semibold dark:text-gray-400">電話番号</p>
-                    <p className="text-slate-900 font-semibold dark:text-white">{office?.phone_number || '未設定'}</p>
-                  </div>
-                  <div>
-                    <p className="text-slate-600 text-base font-semibold dark:text-gray-400">メールアドレス</p>
-                    <p className="text-slate-900 font-semibold dark:text-white">{office?.email || '未設定'}</p>
-                  </div>
-                </div>
-              </div>
+              <OfficeInfoTab
+                office={office}
+                withdrawalSuccess={withdrawalSuccess}
+                onEditOffice={handleOpenOfficeEditModal}
+                onOpenWithdrawal={() => setShowWithdrawalModal(true)}
+              />
 
-              {/* スタッフ管理セクション */}
-              <div className="bg-white p-6 rounded-lg mb-6 border border-slate-300 shadow-sm dark:bg-gray-800 dark:border-gray-700">
-                <div className="flex items-center justify-between mb-4">
-                  <div className="flex items-center gap-3">
-                    <h3 className="text-xl font-semibold">事務所スタッフ管理</h3>
-                    <span className="text-slate-600 text-base font-semibold dark:text-gray-400">
-                      {officeStaffs.length}名
-                    </span>
-
-                    {/* QRコード紛失時のヘルプツールチップ */}
-                    <div className="group relative">
-                      <button className="text-blue-400 hover:text-blue-300 text-base font-semibold flex items-center gap-1 transition-colors">
-                        <AiOutlineQuestionCircle className="h-5 w-5" />
-                        <span className="underline">QRコードを紛失した場合</span>
-                      </button>
-
-                      {/* ツールチップ */}
-                      <div className="absolute left-0 top-full mt-2 w-80 bg-white border border-slate-300 dark:bg-gray-900 dark:border-gray-700 rounded-lg p-4 shadow-xl opacity-0 invisible group-hover:opacity-100 group-hover:visible transition-all duration-200 z-50">
-                        <div className="flex items-start gap-2">
-                          <AiOutlineQuestionCircle className="h-5 w-5 text-blue-400 flex-shrink-0 mt-0.5" />
-                          <div>
-                            <p className="text-base font-semibold text-slate-900 dark:text-white mb-2">QRコード紛失時の対処法</p>
-                            <ol className="text-base text-slate-700 dark:text-gray-300 space-y-2 list-decimal list-inside">
-                              <li>対象スタッフの２段階認証を一度無効化する</li>
-                              <li>再度２段階認証を有効化する</li>
-                              <li>新しいQRコードとシークレットキーが発行される</li>
-                              <li>スタッフに新しいQRコードを共有する</li>
-                            </ol>
-                            <p className="text-sm font-medium text-slate-500 dark:text-gray-400 mt-3">
-                              ⚠️ 無効化すると、既存のTOTPアプリの設定は使用できなくなります。
-                            </p>
-                          </div>
-                        </div>
-                      </div>
-                    </div>
-                  </div>
-                  <div className="flex gap-2">
-                    <button
-                      onClick={handleBulkEnableMfa}
-                      disabled={isBulkMfaProcessing || isLoadingStaffs}
-                      className="bg-green-600 hover:bg-green-700 text-white px-4 py-2 rounded-lg text-base font-semibold disabled:bg-gray-600 disabled:cursor-not-allowed flex items-center gap-2 transition-colors"
-                    >
-                      {isBulkMfaProcessing ? (
-                        <>
-                          <svg className="animate-spin h-4 w-4" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24">
-                            <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4"></circle>
-                            <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"></path>
-                          </svg>
-                          処理中...
-                        </>
-                      ) : (
-                        <>
-                          <MdCheckCircle className="w-5 h-5" />
-                          全員２段階認証有効化
-                        </>
-                      )}
-                    </button>
-                    <button
-                      onClick={handleBulkDisableMfa}
-                      disabled={isBulkMfaProcessing || isLoadingStaffs}
-                      className="bg-red-600 hover:bg-red-700 text-white px-4 py-2 rounded-lg text-base font-semibold disabled:bg-gray-600 disabled:cursor-not-allowed flex items-center gap-2 transition-colors"
-                    >
-                      {isBulkMfaProcessing ? (
-                        <>
-                          <svg className="animate-spin h-4 w-4" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24">
-                            <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4"></circle>
-                            <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"></path>
-                          </svg>
-                          処理中...
-                        </>
-                      ) : (
-                        <>
-                          <MdCancel className="w-5 h-5" />
-                          全員２段階認証無効化
-                        </>
-                      )}
-                    </button>
-                  </div>
-                </div>
-
-                {/* バルク２段階認証操作エラーメッセージ */}
-                {bulkMfaError && (
-                  <div className="mb-4 p-4 bg-red-900/50 border border-red-500 rounded-lg">
-                    <p className="text-red-400 text-base font-semibold">エラー</p>
-                    <p className="text-red-400 text-base font-semibold mt-1">{bulkMfaError}</p>
-                  </div>
-                )}
-
-                {/* バルク２段階認証操作成功メッセージ */}
-                {bulkMfaSuccess && !showBulkMfaResultModal && (
-                  <div className="mb-4 p-4 bg-green-900/50 border border-green-500 rounded-lg">
-                    <p className="text-green-400 text-base font-semibold">成功</p>
-                    <p className="text-green-400 text-base font-semibold mt-1">{bulkMfaSuccess}</p>
-                  </div>
-                )}
-
-                {/* ローディング中 */}
-                {isLoadingStaffs && (
-                  <div className="p-4 bg-slate-100 border border-slate-300 rounded-lg flex dark:bg-gray-700 dark:border-gray-600 items-center">
-                    <svg className="animate-spin h-5 w-5 text-blue-400 mr-3" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24">
-                      <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4"></circle>
-                      <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"></path>
-                    </svg>
-                    <p className="text-slate-600 text-base font-semibold dark:text-gray-400">スタッフ一覧を読み込み中...</p>
-                  </div>
-                )}
-
-                {/* エラー表示 */}
-                {loadStaffsError && !isLoadingStaffs && (
-                  <div className="p-4 bg-red-900/50 border border-red-500 rounded-lg">
-                    <p className="text-red-400 text-base font-semibold">読み込みエラー</p>
-                    <p className="text-red-400 text-base font-semibold mt-1">{loadStaffsError}</p>
-                  </div>
-                )}
-
-
-
-                {/* スタッフ一覧テーブル */}
-                {!isLoadingStaffs && !loadStaffsError && (
-                  <div className="overflow-x-auto">
-                    <table className="w-full">
-                      <thead>
-                        <tr className="border-b border-slate-300 dark:border-gray-700">
-                          <th className="text-left py-3 px-4 text-slate-600 dark:text-gray-400 font-semibold">氏名</th>
-                          <th className="text-left py-3 px-4 text-slate-600 dark:text-gray-400 font-semibold">メールアドレス</th>
-                          <th className="text-left py-3 px-4 text-slate-600 dark:text-gray-400 font-semibold">役割</th>
-                          <th className="text-left py-3 px-4 text-slate-600 dark:text-gray-400 font-semibold">
-                            <div className="flex items-center gap-2">
-                              ２段階認証状態/変更
-                              <div className="relative group/help">
-                                <button
-                                  type="button"
-                                  className="w-4 h-4 rounded-full bg-slate-200 hover:bg-slate-300 text-slate-700 dark:bg-gray-700/50 dark:hover:bg-gray-600/70 dark:text-gray-300 flex items-center justify-center text-sm font-bold transition-colors"
-                                  title="２段階認証について"
-                                >
-                                  ?
-                                </button>
-                                {/* ツールチップ */}
-                                <div className="absolute left-0 top-full mt-2 w-80 bg-white border border-slate-300 dark:bg-gray-900 dark:border-gray-700 rounded-lg p-4 shadow-xl opacity-0 invisible group-hover/help:opacity-100 group-hover/help:visible transition-all duration-200 z-50">
-                                  <div className="flex items-start gap-2">
-                                    <svg className="w-5 h-5 text-blue-400 flex-shrink-0 mt-0.5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                                      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
-                                    </svg>
-                                    <div>
-                                      <p className="text-base font-semibold text-slate-900 dark:text-white mb-2">２段階認証とは</p>
-                                      <p className="text-base text-slate-700 dark:text-gray-300 leading-relaxed mb-3">
-                                        ２段階認証は、パスワードに加えて、スマートフォンアプリで生成される6桁の認証コードを使用する認証方式です。
-                                      </p>
-                                      <ul className="text-base text-slate-700 dark:text-gray-300 space-y-1 list-disc list-inside">
-                                        <li>セキュリティが大幅に向上します</li>
-                                        <li>Google Authenticatorなどのアプリが必要です</li>
-                                        <li>ログイン時に追加の認証コード入力が必要になります</li>
-                                      </ul>
-                                    </div>
-                                  </div>
-                                </div>
-                              </div>
-                            </div>
-                          </th>
-                          <th className="text-left py-3 px-4 text-slate-600 dark:text-gray-400 font-semibold">スタッフ削除</th>
-                        </tr>
-                      </thead>
-                      <tbody>
-                        {officeStaffs.map((s) => {
-                          const isDeleted = s.is_deleted;
-                          const remainingDays = isDeleted ? calculateRemainingDays(s.deleted_at) : 0;
-
-                          return (
-                            <tr key={s.id} className={`border-b border-slate-300 dark:border-gray-700 hover:bg-slate-100 dark:hover:bg-gray-700/50 ${isDeleted ? 'opacity-50' : ''}`}>
-                              <td className="py-3 px-4">
-                                <div className="flex items-center gap-2">
-                                  <span className={isDeleted ? 'text-slate-500 dark:text-gray-500 line-through' : 'text-slate-900 dark:text-white'}>
-                                    {s.full_name}
-                                  </span>
-                                  {isDeleted && (
-                                    <span className="px-2 py-1 rounded-lg text-sm font-semibold bg-red-900/50 text-red-400 border border-red-500">
-                                      削除済み - 残り{remainingDays}日で完全削除
-                                    </span>
-                                  )}
-                                </div>
-                              </td>
-                              <td className="py-3 px-4 text-slate-700 dark:text-gray-300">{s.email}</td>
-                              <td className="py-3 px-4">
-                                <span
-                                  className={`inline-flex min-w-20 justify-center rounded border px-3 py-1 text-base font-semibold ${getRoleBadgeColor(s.role)}`}
-                                >
-                                  {getRoleLabel(s.role)}
-                                </span>
-                              </td>
-                            <td className="py-3 px-4">
-                              <div className="flex items-center gap-2 group">
-                                <span
-                                  className={`inline-flex min-w-20 justify-center rounded border px-3 py-1 text-base font-semibold items-center gap-1 ${
-                                    s.is_mfa_enabled
-                                      ? 'border-green-500 text-green-700 dark:text-green-300'
-                                      : 'border-slate-400 text-slate-600 dark:border-gray-500 dark:text-gray-300'
-                                  }`}
-                                >
-                                  {s.is_mfa_enabled ? (
-                                    <>
-                                      <MdCheckCircle className="w-4 h-4" />
-                                      有効
-                                    </>
-                                  ) : (
-                                    <>
-                                      <MdCancel className="w-4 h-4" />
-                                      無効
-                                    </>
-                                  )}
-                                </span>
-                                {s.is_mfa_enabled ? (
-                                  <button
-                                    onClick={() => handleStaffMfaDisable(s)}
-                                    disabled={staffMfaTogglingId === s.id || isDeleted}
-                                    className="opacity-0 group-hover:opacity-100 transition-opacity bg-red-600 hover:bg-red-700 text-white px-3 py-1 rounded text-base font-semibold disabled:bg-gray-600 disabled:cursor-not-allowed flex items-center gap-1"
-                                  >
-                                    {staffMfaTogglingId === s.id ? (
-                                      <>
-                                        <svg className="animate-spin h-4 w-4" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24">
-                                          <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4"></circle>
-                                          <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"></path>
-                                        </svg>
-                                        処理中...
-                                      </>
-                                    ) : (
-                                      '無効化'
-                                    )}
-                                  </button>
-                                ) : (
-                                  <button
-                                    onClick={() => handleStaffMfaEnable(s)}
-                                    disabled={staffMfaTogglingId === s.id || isDeleted}
-                                    className="opacity-0 group-hover:opacity-100 transition-opacity bg-blue-600 hover:bg-blue-700 text-white px-3 py-1 rounded text-base font-semibold disabled:bg-gray-600 disabled:cursor-not-allowed flex items-center gap-1"
-                                  >
-                                    {staffMfaTogglingId === s.id ? (
-                                      <>
-                                        <svg className="animate-spin h-4 w-4" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24">
-                                          <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4"></circle>
-                                          <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"></path>
-                                        </svg>
-                                        処理中...
-                                      </>
-                                    ) : (
-                                      '有効化'
-                                    )}
-                                  </button>
-                                )}
-                              </div>
-                            </td>
-                              <td className="py-3 px-4">
-                                {isDeleted ? (
-                                  <span className="text-slate-500 dark:text-gray-500 text-base">削除済み</span>
-                                ) : (
-                                  <button
-                                    onClick={() => handleStaffDelete(s)}
-                                    disabled={staffDeletingId === s.id}
-                                    className="bg-red-600 hover:bg-red-700 text-white px-3 py-1 rounded text-base font-semibold disabled:bg-gray-600 disabled:cursor-not-allowed flex items-center gap-1"
-                                  >
-                                    {staffDeletingId === s.id ? (
-                                      <>
-                                        <svg className="animate-spin h-4 w-4" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24">
-                                          <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4"></circle>
-                                          <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"></path>
-                                        </svg>
-                                        削除中...
-                                      </>
-                                    ) : (
-                                      <>
-                                        <MdDelete className="w-4 h-4" />
-                                        削除
-                                      </>
-                                    )}
-                                  </button>
-                                )}
-                              </td>
-                            </tr>
-                          );
-                        })}
-                      </tbody>
-                    </table>
-                  </div>
-                )}
-              </div>
-
-              {/* 退会セクション */}
-              <div className="bg-white p-6 rounded-lg mt-6 border border-red-300 shadow-sm dark:bg-gray-800 dark:border-red-500/30">
-                <div className="flex items-center gap-3 mb-4">
-                  <MdExitToApp className="w-6 h-6 text-red-400" />
-                  <h3 className="text-xl font-semibold text-red-400">退会</h3>
-                </div>
-
-                {withdrawalSuccess && (
-                  <div className="mb-4 p-4 bg-green-900/50 border border-green-500 rounded-lg">
-                    <p className="text-green-400 text-base">{withdrawalSuccess}</p>
-                  </div>
-                )}
-
-                <p className="text-slate-600 mb-4 dark:text-gray-400 text-base">
-                  事務所を退会すると、事務所データと全スタッフのアカウントが削除されます。
-                  退会申請後、アプリ管理者による承認が必要です。
-                </p>
-                <button
-                  onClick={() => setShowWithdrawalModal(true)}
-                  className="flex items-center gap-2 bg-red-600 hover:bg-red-700 text-white px-4 py-2 rounded-lg transition-colors"
-                >
-                  <MdExitToApp className="w-5 h-5" />
-                  退会を申請する
-                </button>
-              </div>
+              <StaffManagementTab
+                officeStaffs={officeStaffs}
+                isLoadingStaffs={isLoadingStaffs}
+                loadStaffsError={loadStaffsError}
+                staffMfaTogglingId={staffMfaTogglingId}
+                staffDeletingId={staffDeletingId}
+                isBulkMfaProcessing={isBulkMfaProcessing}
+                bulkMfaError={bulkMfaError}
+                bulkMfaSuccess={bulkMfaSuccess}
+                showBulkMfaResultModal={showBulkMfaResultModal}
+                onBulkEnableMfa={handleBulkEnableMfa}
+                onBulkDisableMfa={handleBulkDisableMfa}
+                onStaffMfaEnable={handleStaffMfaEnable}
+                onStaffMfaDisable={handleStaffMfaDisable}
+                onStaffDelete={handleStaffDelete}
+                calculateRemainingDays={calculateRemainingDays}
+                getRoleBadgeColor={getRoleBadgeColor}
+                getRoleLabel={getRoleLabel}
+              />
             </div>
           )}
 
           {/* オフィス: 連携 */}
           {activeTab === 'integration' && (
-            <div>
-              <h2 className="text-2xl font-bold mb-4">連携</h2>
-
-              <div className="bg-white p-6 rounded-lg border border-slate-300 shadow-sm dark:bg-gray-800 dark:border-gray-700">
-                <h3 className="text-xl font-semibold mb-4">Google カレンダー</h3>
-                <p className="text-slate-600 mb-4 dark:text-gray-400">
-                  Google Calendarへの通知はGoogle Consoleから設定します 詳しくは下記を参照してください
-                </p>
-
-                <div className="mb-4">
-                  <a
-                    href="https://www.youtube.com/watch?v=xAXWnT_kP2g"
-                    target="_blank"
-                    rel="noopener noreferrer"
-                    className="text-blue-400 hover:text-blue-300 underline"
-                  >
-                    Google Calendar設定方法
-                  </a>
-                </div>
-
-                {/* ローディング中 */}
-                {isLoadingCalendar && (
-                  <div className="mb-4 p-4 bg-slate-100 border border-slate-300 rounded-lg flex dark:bg-gray-700 dark:border-gray-600 items-center">
-                    <svg className="animate-spin h-5 w-5 text-blue-400 mr-3" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24">
-                      <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4"></circle>
-                      <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"></path>
-                    </svg>
-                    <p className="text-slate-600 text-base font-semibold dark:text-gray-400">設定を読み込み中...</p>
-                  </div>
-                )}
-
-                {/* カレンダー設定読み込みエラー */}
-                {loadCalendarError && (
-                  <div className="mb-4 p-4 bg-red-900/50 border border-red-500 rounded-lg">
-                    <p className="text-red-400 text-base font-semibold">設定の読み込みエラー</p>
-                    <p className="text-red-400 text-base font-semibold mt-1">{loadCalendarError}</p>
-                  </div>
-                )}
-
-                {/* 既存のカレンダー設定情報 */}
-                {existingCalendar && !isLoadingCalendar && (
-                  <div className="mb-6 p-4 bg-slate-100 border border-slate-300 rounded-lg dark:bg-gray-700 dark:border-gray-600">
-                    <h4 className="text-xl font-semibold mb-3 flex items-center gap-2">
-                      <svg className="w-5 h-5 text-green-400" fill="currentColor" viewBox="0 0 20 20">
-                        <path fillRule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zm3.707-9.293a1 1 0 00-1.414-1.414L9 10.586 7.707 9.293a1 1 0 00-1.414 1.414l2 2a1 1 0 001.414 0l4-4z" clipRule="evenodd" />
-                      </svg>
-                      現在の設定
-                    </h4>
-                    <div className="space-y-3">
-                      <div>
-                        <p className="text-slate-600 text-base font-semibold dark:text-gray-400">接続ステータス</p>
-                        <span className={`inline-block mt-1 px-3 py-1 rounded-lg text-base font-semibold border ${getConnectionStatusColor(existingCalendar.connection_status)}`}>
-                          {getConnectionStatusLabel(existingCalendar.connection_status)}
-                        </span>
-                      </div>
-                      {existingCalendar.google_calendar_id && (
-                        <div>
-                          <p className="text-slate-600 text-base font-semibold dark:text-gray-400">カレンダー ID</p>
-                          <p className="text-slate-900 font-mono text-base font-semibold dark:text-white mt-1 break-all">{existingCalendar.google_calendar_id}</p>
-                        </div>
-                      )}
-                      {existingCalendar.service_account_email && (
-                        <div>
-                          <p className="text-slate-600 text-base font-semibold dark:text-gray-400">サービスアカウント</p>
-                          <p className="text-slate-900 font-mono text-base font-semibold dark:text-white mt-1 break-all">{existingCalendar.service_account_email}</p>
-                        </div>
-                      )}
-                      {existingCalendar.calendar_name && (
-                        <div>
-                          <p className="text-slate-600 text-base font-semibold dark:text-gray-400">カレンダー名</p>
-                          <p className="text-slate-900 text-base font-semibold dark:text-white mt-1">{existingCalendar.calendar_name}</p>
-                        </div>
-                      )}
-                      {existingCalendar.last_sync_at && (
-                        <div>
-                          <p className="text-slate-600 text-base font-semibold dark:text-gray-400">最終同期日時</p>
-                          <p className="text-slate-900 text-base font-semibold dark:text-white mt-1">{new Date(existingCalendar.last_sync_at).toLocaleString('ja-JP')}</p>
-                        </div>
-                      )}
-                      {existingCalendar.last_error_message && (
-                        <div>
-                          <p className="text-red-400 text-base font-semibold">最後のエラー</p>
-                          <p className="text-red-300 text-base font-semibold mt-1">{existingCalendar.last_error_message}</p>
-                        </div>
-                      )}
-                    </div>
-                  </div>
-                )}
-
-                {/* アップロードエラー */}
-                {uploadError && (
-                  <div className="mb-4 p-4 bg-red-900/50 border border-red-500 rounded-lg">
-                    <p className="text-red-400 text-base font-semibold">アップロードエラー</p>
-                    <p className="text-red-400 text-base font-semibold mt-1">{uploadError}</p>
-                  </div>
-                )}
-
-                {/* アップロード成功 */}
-                {uploadSuccess && (
-                  <div className="mb-4 p-4 bg-green-900/50 border border-green-500 rounded-lg">
-                    <p className="text-green-400 text-base">{uploadSuccess}</p>
-                  </div>
-                )}
-
-                {/* 削除エラー */}
-                {deleteError && (
-                  <div className="mb-4 p-4 bg-red-900/50 border border-red-500 rounded-lg">
-                    <p className="text-red-400 text-base font-semibold">削除エラー</p>
-                    <p className="text-red-400 text-base font-semibold mt-1">{deleteError}</p>
-                  </div>
-                )}
-
-                {/* 削除成功 */}
-                {deleteSuccess && (
-                  <div className="mb-4 p-4 bg-green-900/50 border border-green-500 rounded-lg">
-                    <p className="text-green-400 text-base">{deleteSuccess}</p>
-                  </div>
-                )}
-
-                <div className="space-y-4">
-                  <h4 className="text-xl font-semibold mb-3">
-                    {existingCalendar ? '設定を更新' : '新規設定'}
-                  </h4>
-
-                  <div>
-                    <label className="block text-slate-600 text-base font-semibold dark:text-gray-400 mb-2">
-                      カレンダー ID <span className="text-red-400">*</span>
-                    </label>
-                    <input
-                      type="text"
-                      value={calendarId}
-                      onChange={(e) => setCalendarId(e.target.value)}
-                      placeholder="example@group.calendar.google.com"
-                      className="w-full bg-white border border-slate-300 rounded-lg px-4 py-2 text-slate-900 placeholder-slate-400 dark:bg-gray-700 dark:border-gray-600 dark:text-white dark:placeholder-gray-500"
-                    />
-                    <p className="mt-1 text-sm font-medium text-slate-500 dark:text-gray-500">
-                      Googleカレンダーの設定から取得できます
-                    </p>
-                  </div>
-
-                  <div>
-                    <label className="block text-slate-600 text-base font-semibold dark:text-gray-400 mb-2">
-                      サービスアカウント JSON ファイル <span className="text-red-400">*</span>
-                    </label>
-                    <input
-                      type="file"
-                      accept=".json"
-                      onChange={handleFileChange}
-                      className="w-full text-slate-700 dark:text-gray-300 file:mr-4 file:py-2 file:px-4 file:rounded-lg file:border-0 file:text-base file:font-semibold file:bg-blue-600 file:text-white hover:file:bg-blue-700"
-                    />
-                    {calendarFile && (
-                      <p className="mt-2 text-base font-semibold text-green-400">
-                        選択済み: {calendarFile.name}
-                      </p>
-                    )}
-                    {existingCalendar && !calendarFile && (
-                      <p className="mt-1 text-sm font-medium text-slate-500 dark:text-gray-500">
-                        既存の認証情報が設定されています。変更する場合のみファイルを選択してください。
-                      </p>
-                    )}
-                  </div>
-
-                  <button
-                    onClick={handleCalendarSubmit}
-                    disabled={!calendarFile || !calendarId || isUploading}
-                    className="bg-blue-600 hover:bg-blue-700 text-white px-6 py-2 rounded-lg disabled:bg-gray-600 disabled:cursor-not-allowed flex items-center"
-                  >
-                    {isUploading ? (
-                      <>
-                        <svg className="animate-spin -ml-1 mr-3 h-5 w-5 text-white" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24">
-                          <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4"></circle>
-                          <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"></path>
-                        </svg>
-                        アップロード中...
-                      </>
-                    ) : existingCalendar ? (
-                      '設定を更新'
-                    ) : (
-                      'アップロード'
-                    )}
-                  </button>
-                </div>
-
-                {/* 連携解除セクション */}
-                {existingCalendar && (
-                  <div className="mt-8 pt-6 border-t border-slate-300 dark:border-gray-700">
-                    <h4 className="text-xl font-semibold mb-3 text-red-400">カレンダー連携解除</h4>
-                    <p className="text-slate-600 text-base font-semibold dark:text-slate-600 mb-4 dark:text-gray-400">
-                      カレンダー連携を解除すると、今後のイベント同期が停止されます。この操作は元に戻せません。
-                    </p>
-
-                    {!showDeleteConfirm ? (
-                      <button
-                        onClick={() => setShowDeleteConfirm(true)}
-                        className="bg-red-600 hover:bg-red-700 text-white px-6 py-2 rounded-lg"
-                      >
-                        連携解除
-                      </button>
-                    ) : (
-                      <div className="bg-red-900/30 border border-red-600 rounded-lg p-4">
-                        <p className="text-red-400 font-semibold mb-3">
-                          本当にカレンダー連携を解除しますか？
-                        </p>
-                        <div className="flex gap-3">
-                          <button
-                            onClick={handleCalendarDelete}
-                            disabled={isDeleting}
-                            className="bg-red-600 hover:bg-red-700 text-white px-4 py-2 rounded-lg disabled:bg-gray-600 disabled:cursor-not-allowed flex items-center"
-                          >
-                            {isDeleting ? (
-                              <>
-                                <svg className="animate-spin -ml-1 mr-3 h-5 w-5 text-white" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24">
-                                  <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4"></circle>
-                                  <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"></path>
-                                </svg>
-                                解除中...
-                              </>
-                            ) : (
-                              '解除を実行'
-                            )}
-                          </button>
-                          <button
-                            onClick={() => setShowDeleteConfirm(false)}
-                            disabled={isDeleting}
-                            className="bg-slate-200 hover:bg-slate-300 text-slate-900 dark:bg-gray-600 dark:hover:bg-gray-700 dark:text-white px-4 py-2 rounded-lg disabled:cursor-not-allowed"
-                          >
-                            キャンセル
-                          </button>
-                        </div>
-                      </div>
-                    )}
-                  </div>
-                )}
-              </div>
-            </div>
+            <GoogleIntegrationTab
+              calendarFile={calendarFile}
+              calendarId={calendarId}
+              existingCalendar={existingCalendar}
+              isLoadingCalendar={isLoadingCalendar}
+              loadCalendarError={loadCalendarError}
+              uploadError={uploadError}
+              uploadSuccess={uploadSuccess}
+              deleteError={deleteError}
+              deleteSuccess={deleteSuccess}
+              isUploading={isUploading}
+              showDeleteConfirm={showDeleteConfirm}
+              isDeleting={isDeleting}
+              onCalendarIdChange={setCalendarId}
+              onFileChange={handleFileChange}
+              onCalendarSubmit={handleCalendarSubmit}
+              onCalendarDelete={handleCalendarDelete}
+              onShowDeleteConfirmChange={setShowDeleteConfirm}
+              getConnectionStatusLabel={getConnectionStatusLabel}
+              getConnectionStatusColor={getConnectionStatusColor}
+            />
           )}
 
           {/* オフィス: 有料会員 */}
-          {activeTab === 'plan' && <PlanTab />}
+          {activeTab === 'plan' && <BillingPlanTab />}
         </div>
       </div>
 
@@ -1304,128 +764,23 @@ export default function AdminMenu({ office }: AdminMenuProps) {
 
       {/* オフィス編集モーダル */}
       {showOfficeEditModal && (
-        <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50 p-4">
-          <div className="bg-white rounded-lg p-6 font-medium border border-slate-300 shadow-sm dark:bg-gray-800 dark:border-gray-700 max-w-2xl w-full max-h-[90vh] overflow-y-auto">
-            <h3 className="text-2xl font-bold mb-4 text-slate-900 dark:text-white">事業所情報を編集</h3>
-
-            {/* エラーメッセージ */}
-            {saveOfficeError && (
-              <div className="mb-4 p-4 bg-red-900/50 border border-red-500 rounded-lg">
-                <p className="text-red-400 text-base font-semibold">エラー</p>
-                <p className="text-red-400 text-base font-semibold mt-1">{saveOfficeError}</p>
-              </div>
-            )}
-
-            {/* 成功メッセージ */}
-            {saveOfficeSuccess && (
-              <div className="mb-4 p-4 bg-green-900/50 border border-green-500 rounded-lg">
-                <p className="text-green-400 text-base">{saveOfficeSuccess}</p>
-              </div>
-            )}
-
-            <div className="space-y-4">
-              <div>
-                <label className="block text-slate-600 text-base font-semibold dark:text-gray-400 mb-2">
-                  事業所名 <span className="text-red-400">*</span>
-                </label>
-                <input
-                  type="text"
-                  value={officeName}
-                  onChange={(e) => setOfficeName(e.target.value)}
-                  className="w-full bg-white border border-slate-300 rounded-lg px-4 py-2 text-slate-900 dark:bg-gray-700 dark:border-gray-600 dark:text-white focus:outline-none focus:border-blue-500"
-                  placeholder="事業所名を入力"
-                  required
-                  minLength={1}
-                  maxLength={255}
-                  disabled={isSavingOffice}
-                />
-              </div>
-
-              <div>
-                <label className="block text-slate-600 text-base font-semibold dark:text-gray-400 mb-2">事業所種別</label>
-                <select
-                  value={officeType}
-                  onChange={(e) => setOfficeType(e.target.value as OfficeTypeValue)}
-                  className="w-full bg-white border border-slate-300 rounded-lg px-4 py-2 text-slate-900 dark:bg-gray-700 dark:border-gray-600 dark:text-white focus:outline-none focus:border-blue-500"
-                  disabled={isSavingOffice}
-                >
-                  <option value="transition_to_employment">移行支援</option>
-                  <option value="type_A_office">就労A型</option>
-                  <option value="type_B_office">就労B型</option>
-                </select>
-              </div>
-
-              <div>
-                <label className="block text-slate-600 text-base font-semibold dark:text-gray-400 mb-2">住所</label>
-                <input
-                  type="text"
-                  value={officeAddress}
-                  onChange={(e) => setOfficeAddress(e.target.value)}
-                  className="w-full bg-white border border-slate-300 rounded-lg px-4 py-2 text-slate-900 dark:bg-gray-700 dark:border-gray-600 dark:text-white focus:outline-none focus:border-blue-500"
-                  placeholder="例: 東京都渋谷区1-2-3"
-                  maxLength={500}
-                  disabled={isSavingOffice}
-                />
-              </div>
-
-              <div>
-                <label className="block text-slate-600 text-base font-semibold dark:text-gray-400 mb-2">電話番号</label>
-                <input
-                  type="tel"
-                  value={officePhoneNumber}
-                  onChange={(e) => setOfficePhoneNumber(e.target.value)}
-                  className="w-full bg-white border border-slate-300 rounded-lg px-4 py-2 text-slate-900 dark:bg-gray-700 dark:border-gray-600 dark:text-white focus:outline-none focus:border-blue-500"
-                  placeholder="例: 03-1234-5678"
-                  pattern="\d{2,4}-\d{2,4}-\d{4}"
-                  disabled={isSavingOffice}
-                />
-                <p className="mt-1 text-sm font-medium text-slate-500 dark:text-gray-500">
-                  形式: 03-1234-5678（ハイフン区切り）
-                </p>
-              </div>
-
-              <div>
-                <label className="block text-slate-600 text-base font-semibold dark:text-gray-400 mb-2">メールアドレス</label>
-                <input
-                  type="email"
-                  value={officeEmail}
-                  onChange={(e) => setOfficeEmail(e.target.value)}
-                  className="w-full bg-white border border-slate-300 rounded-lg px-4 py-2 text-slate-900 dark:bg-gray-700 dark:border-gray-600 dark:text-white focus:outline-none focus:border-blue-500"
-                  placeholder="例: info@example.com"
-                  disabled={isSavingOffice}
-                />
-              </div>
-            </div>
-
-            {/* ボタン */}
-            <div className="flex justify-end gap-3 mt-6">
-              <button
-                onClick={() => setShowOfficeEditModal(false)}
-                disabled={isSavingOffice}
-                className="bg-slate-200 hover:bg-slate-300 text-slate-900 dark:bg-gray-600 dark:hover:bg-gray-700 dark:text-white px-4 py-2 rounded-lg disabled:opacity-50 disabled:cursor-not-allowed"
-              >
-                キャンセル
-              </button>
-              <button
-                onClick={handleSaveOfficeEdit}
-                disabled={isSavingOffice}
-                className="bg-blue-600 hover:bg-blue-700 text-white px-4 py-2 rounded-lg disabled:opacity-50 disabled:cursor-not-allowed flex items-center gap-2"
-              >
-                {isSavingOffice ? (
-                  <>
-                    <svg className="animate-spin h-4 w-4" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24">
-                      <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4"></circle>
-                      <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"></path>
-                    </svg>
-                    保存中...
-                  </>
-                ) : (
-                  '保存'
-                )}
-              </button>
-            </div>
-          </div>
-        </div>
+        <OfficeEditModal
+          officeName={officeName}
+          officeType={officeType}
+          officeAddress={officeAddress}
+          officePhoneNumber={officePhoneNumber}
+          officeEmail={officeEmail}
+          isSavingOffice={isSavingOffice}
+          saveOfficeError={saveOfficeError}
+          saveOfficeSuccess={saveOfficeSuccess}
+          onOfficeNameChange={setOfficeName}
+          onOfficeTypeChange={setOfficeType}
+          onOfficeAddressChange={setOfficeAddress}
+          onOfficePhoneNumberChange={setOfficePhoneNumber}
+          onOfficeEmailChange={setOfficeEmail}
+          onClose={() => setShowOfficeEditModal(false)}
+          onSave={handleSaveOfficeEdit}
+        />
       )}
 
       {/* バルク２段階認証有効化結果モーダル */}

--- a/components/protected/admin/AdminMenu.tsx
+++ b/components/protected/admin/AdminMenu.tsx
@@ -213,8 +213,8 @@ export default function AdminMenu({ office }: AdminMenuProps) {
         try {
           const calendar = await calendarApi.getOfficeCalendar(office.id);
           setExistingCalendar(calendar);
-        } catch (refreshError) {
-          console.error('カレンダー設定の再取得に失敗:', refreshError);
+        } catch {
+          console.error('カレンダー設定の再取得に失敗');
         }
       } else {
         setUploadError(response.error_details || '保存に失敗しました。');

--- a/components/protected/admin/BillingPlanTab.tsx
+++ b/components/protected/admin/BillingPlanTab.tsx
@@ -1,0 +1,3 @@
+'use client';
+
+export { default } from './PlanTab';

--- a/components/protected/admin/GoogleIntegrationTab.tsx
+++ b/components/protected/admin/GoogleIntegrationTab.tsx
@@ -1,0 +1,277 @@
+'use client';
+
+import { CalendarConnectionStatus, OfficeCalendarAccount } from '@/types/calendar';
+
+interface GoogleIntegrationTabProps {
+  calendarFile: File | null;
+  calendarId: string;
+  existingCalendar: OfficeCalendarAccount | null;
+  isLoadingCalendar: boolean;
+  loadCalendarError: string | null;
+  uploadError: string | null;
+  uploadSuccess: string | null;
+  deleteError: string | null;
+  deleteSuccess: string | null;
+  isUploading: boolean;
+  showDeleteConfirm: boolean;
+  isDeleting: boolean;
+  onCalendarIdChange: (calendarId: string) => void;
+  onFileChange: (event: React.ChangeEvent<HTMLInputElement>) => void;
+  onCalendarSubmit: () => void;
+  onCalendarDelete: () => void;
+  onShowDeleteConfirmChange: (show: boolean) => void;
+  getConnectionStatusLabel: (status: CalendarConnectionStatus) => string;
+  getConnectionStatusColor: (status: CalendarConnectionStatus) => string;
+}
+
+export default function GoogleIntegrationTab({
+  calendarFile,
+  calendarId,
+  existingCalendar,
+  isLoadingCalendar,
+  loadCalendarError,
+  uploadError,
+  uploadSuccess,
+  deleteError,
+  deleteSuccess,
+  isUploading,
+  showDeleteConfirm,
+  isDeleting,
+  onCalendarIdChange,
+  onFileChange,
+  onCalendarSubmit,
+  onCalendarDelete,
+  onShowDeleteConfirmChange,
+  getConnectionStatusLabel,
+  getConnectionStatusColor,
+}: GoogleIntegrationTabProps) {
+  return (
+    <div>
+      <h2 className="text-2xl font-bold mb-4">連携</h2>
+
+      <div className="bg-white p-6 rounded-lg border border-slate-300 shadow-sm dark:bg-gray-800 dark:border-gray-700">
+        <h3 className="text-xl font-semibold mb-4">Google カレンダー</h3>
+        <p className="text-slate-600 mb-4 dark:text-gray-400">
+          Google Calendarへの通知はGoogle Consoleから設定します 詳しくは下記を参照してください
+        </p>
+
+        <div className="mb-4">
+          <a
+            href="https://www.youtube.com/watch?v=xAXWnT_kP2g"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="text-blue-400 hover:text-blue-300 underline"
+          >
+            Google Calendar設定方法
+          </a>
+        </div>
+
+        {isLoadingCalendar && (
+          <div className="mb-4 p-4 bg-slate-100 border border-slate-300 rounded-lg flex dark:bg-gray-700 dark:border-gray-600 items-center">
+            <SpinnerIcon className="animate-spin h-5 w-5 text-blue-400 mr-3" />
+            <p className="text-slate-600 text-base font-semibold dark:text-gray-400">設定を読み込み中...</p>
+          </div>
+        )}
+
+        {loadCalendarError && (
+          <div className="mb-4 p-4 bg-red-900/50 border border-red-500 rounded-lg">
+            <p className="text-red-400 text-base font-semibold">設定の読み込みエラー</p>
+            <p className="text-red-400 text-base font-semibold mt-1">{loadCalendarError}</p>
+          </div>
+        )}
+
+        {existingCalendar && !isLoadingCalendar && (
+          <div className="mb-6 p-4 bg-slate-100 border border-slate-300 rounded-lg dark:bg-gray-700 dark:border-gray-600">
+            <h4 className="text-xl font-semibold mb-3 flex items-center gap-2">
+              <svg className="w-5 h-5 text-green-400" fill="currentColor" viewBox="0 0 20 20">
+                <path fillRule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zm3.707-9.293a1 1 0 00-1.414-1.414L9 10.586 7.707 9.293a1 1 0 00-1.414 1.414l2 2a1 1 0 001.414 0l4-4z" clipRule="evenodd" />
+              </svg>
+              現在の設定
+            </h4>
+            <div className="space-y-3">
+              <div>
+                <p className="text-slate-600 text-base font-semibold dark:text-gray-400">接続ステータス</p>
+                <span className={`inline-block mt-1 px-3 py-1 rounded-lg text-base font-semibold border ${getConnectionStatusColor(existingCalendar.connection_status)}`}>
+                  {getConnectionStatusLabel(existingCalendar.connection_status)}
+                </span>
+              </div>
+              {existingCalendar.google_calendar_id && (
+                <div>
+                  <p className="text-slate-600 text-base font-semibold dark:text-gray-400">カレンダー ID</p>
+                  <p className="text-slate-900 font-mono text-base font-semibold dark:text-white mt-1 break-all">{existingCalendar.google_calendar_id}</p>
+                </div>
+              )}
+              {existingCalendar.service_account_email && (
+                <div>
+                  <p className="text-slate-600 text-base font-semibold dark:text-gray-400">サービスアカウント</p>
+                  <p className="text-slate-900 font-mono text-base font-semibold dark:text-white mt-1 break-all">{existingCalendar.service_account_email}</p>
+                </div>
+              )}
+              {existingCalendar.calendar_name && (
+                <div>
+                  <p className="text-slate-600 text-base font-semibold dark:text-gray-400">カレンダー名</p>
+                  <p className="text-slate-900 text-base font-semibold dark:text-white mt-1">{existingCalendar.calendar_name}</p>
+                </div>
+              )}
+              {existingCalendar.last_sync_at && (
+                <div>
+                  <p className="text-slate-600 text-base font-semibold dark:text-gray-400">最終同期日時</p>
+                  <p className="text-slate-900 text-base font-semibold dark:text-white mt-1">{new Date(existingCalendar.last_sync_at).toLocaleString('ja-JP')}</p>
+                </div>
+              )}
+              {existingCalendar.last_error_message && (
+                <div>
+                  <p className="text-red-400 text-base font-semibold">最後のエラー</p>
+                  <p className="text-red-300 text-base font-semibold mt-1">{existingCalendar.last_error_message}</p>
+                </div>
+              )}
+            </div>
+          </div>
+        )}
+
+        {uploadError && (
+          <div className="mb-4 p-4 bg-red-900/50 border border-red-500 rounded-lg">
+            <p className="text-red-400 text-base font-semibold">アップロードエラー</p>
+            <p className="text-red-400 text-base font-semibold mt-1">{uploadError}</p>
+          </div>
+        )}
+
+        {uploadSuccess && (
+          <div className="mb-4 p-4 bg-green-900/50 border border-green-500 rounded-lg">
+            <p className="text-green-400 text-base">{uploadSuccess}</p>
+          </div>
+        )}
+
+        {deleteError && (
+          <div className="mb-4 p-4 bg-red-900/50 border border-red-500 rounded-lg">
+            <p className="text-red-400 text-base font-semibold">削除エラー</p>
+            <p className="text-red-400 text-base font-semibold mt-1">{deleteError}</p>
+          </div>
+        )}
+
+        {deleteSuccess && (
+          <div className="mb-4 p-4 bg-green-900/50 border border-green-500 rounded-lg">
+            <p className="text-green-400 text-base">{deleteSuccess}</p>
+          </div>
+        )}
+
+        <div className="space-y-4">
+          <h4 className="text-xl font-semibold mb-3">
+            {existingCalendar ? '設定を更新' : '新規設定'}
+          </h4>
+
+          <div>
+            <label className="block text-slate-600 text-base font-semibold dark:text-gray-400 mb-2">
+              カレンダー ID <span className="text-red-400">*</span>
+            </label>
+            <input
+              type="text"
+              value={calendarId}
+              onChange={(event) => onCalendarIdChange(event.target.value)}
+              placeholder="example@group.calendar.google.com"
+              className="w-full bg-white border border-slate-300 rounded-lg px-4 py-2 text-slate-900 placeholder-slate-400 dark:bg-gray-700 dark:border-gray-600 dark:text-white dark:placeholder-gray-500"
+            />
+            <p className="mt-1 text-sm font-medium text-slate-500 dark:text-gray-500">
+              Googleカレンダーの設定から取得できます
+            </p>
+          </div>
+
+          <div>
+            <label className="block text-slate-600 text-base font-semibold dark:text-gray-400 mb-2">
+              サービスアカウント JSON ファイル <span className="text-red-400">*</span>
+            </label>
+            <input
+              type="file"
+              accept=".json"
+              onChange={onFileChange}
+              className="w-full text-slate-700 dark:text-gray-300 file:mr-4 file:py-2 file:px-4 file:rounded-lg file:border-0 file:text-base file:font-semibold file:bg-blue-600 file:text-white hover:file:bg-blue-700"
+            />
+            {calendarFile && (
+              <p className="mt-2 text-base font-semibold text-green-400">
+                選択済み: {calendarFile.name}
+              </p>
+            )}
+            {existingCalendar && !calendarFile && (
+              <p className="mt-1 text-sm font-medium text-slate-500 dark:text-gray-500">
+                既存の認証情報が設定されています。変更する場合のみファイルを選択してください。
+              </p>
+            )}
+          </div>
+
+          <button
+            onClick={onCalendarSubmit}
+            disabled={!calendarFile || !calendarId || isUploading}
+            className="bg-blue-600 hover:bg-blue-700 text-white px-6 py-2 rounded-lg disabled:bg-gray-600 disabled:cursor-not-allowed flex items-center"
+          >
+            {isUploading ? (
+              <>
+                <SpinnerIcon className="animate-spin -ml-1 mr-3 h-5 w-5 text-white" />
+                アップロード中...
+              </>
+            ) : existingCalendar ? (
+              '設定を更新'
+            ) : (
+              'アップロード'
+            )}
+          </button>
+        </div>
+
+        {existingCalendar && (
+          <div className="mt-8 pt-6 border-t border-slate-300 dark:border-gray-700">
+            <h4 className="text-xl font-semibold mb-3 text-red-400">カレンダー連携解除</h4>
+            <p className="text-slate-600 text-base font-semibold dark:text-slate-600 mb-4 dark:text-gray-400">
+              カレンダー連携を解除すると、今後のイベント同期が停止されます。この操作は元に戻せません。
+            </p>
+
+            {!showDeleteConfirm ? (
+              <button
+                onClick={() => onShowDeleteConfirmChange(true)}
+                className="bg-red-600 hover:bg-red-700 text-white px-6 py-2 rounded-lg"
+              >
+                連携解除
+              </button>
+            ) : (
+              <div className="bg-red-900/30 border border-red-600 rounded-lg p-4">
+                <p className="text-red-400 font-semibold mb-3">
+                  本当にカレンダー連携を解除しますか？
+                </p>
+                <div className="flex gap-3">
+                  <button
+                    onClick={onCalendarDelete}
+                    disabled={isDeleting}
+                    className="bg-red-600 hover:bg-red-700 text-white px-4 py-2 rounded-lg disabled:bg-gray-600 disabled:cursor-not-allowed flex items-center"
+                  >
+                    {isDeleting ? (
+                      <>
+                        <SpinnerIcon className="animate-spin -ml-1 mr-3 h-5 w-5 text-white" />
+                        解除中...
+                      </>
+                    ) : (
+                      '解除を実行'
+                    )}
+                  </button>
+                  <button
+                    onClick={() => onShowDeleteConfirmChange(false)}
+                    disabled={isDeleting}
+                    className="bg-slate-200 hover:bg-slate-300 text-slate-900 dark:bg-gray-600 dark:hover:bg-gray-700 dark:text-white px-4 py-2 rounded-lg disabled:cursor-not-allowed"
+                  >
+                    キャンセル
+                  </button>
+                </div>
+              </div>
+            )}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
+
+function SpinnerIcon({ className = 'animate-spin h-4 w-4' }: { className?: string }) {
+  return (
+    <svg className={className} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24">
+      <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4"></circle>
+      <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"></path>
+    </svg>
+  );
+}

--- a/components/protected/admin/OfficeEditModal.tsx
+++ b/components/protected/admin/OfficeEditModal.tsx
@@ -1,0 +1,161 @@
+'use client';
+
+import { OfficeTypeValue } from '@/types/office';
+
+interface OfficeEditModalProps {
+  officeName: string;
+  officeType: OfficeTypeValue;
+  officeAddress: string;
+  officePhoneNumber: string;
+  officeEmail: string;
+  isSavingOffice: boolean;
+  saveOfficeError: string | null;
+  saveOfficeSuccess: string | null;
+  onOfficeNameChange: (value: string) => void;
+  onOfficeTypeChange: (value: OfficeTypeValue) => void;
+  onOfficeAddressChange: (value: string) => void;
+  onOfficePhoneNumberChange: (value: string) => void;
+  onOfficeEmailChange: (value: string) => void;
+  onClose: () => void;
+  onSave: () => void;
+}
+
+export default function OfficeEditModal({
+  officeName,
+  officeType,
+  officeAddress,
+  officePhoneNumber,
+  officeEmail,
+  isSavingOffice,
+  saveOfficeError,
+  saveOfficeSuccess,
+  onOfficeNameChange,
+  onOfficeTypeChange,
+  onOfficeAddressChange,
+  onOfficePhoneNumberChange,
+  onOfficeEmailChange,
+  onClose,
+  onSave,
+}: OfficeEditModalProps) {
+  return (
+    <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50 p-4">
+      <div className="bg-white rounded-lg p-6 font-medium border border-slate-300 shadow-sm dark:bg-gray-800 dark:border-gray-700 max-w-2xl w-full max-h-[90vh] overflow-y-auto">
+        <h3 className="text-2xl font-bold mb-4 text-slate-900 dark:text-white">事業所情報を編集</h3>
+
+        {saveOfficeError && (
+          <div className="mb-4 p-4 bg-red-900/50 border border-red-500 rounded-lg">
+            <p className="text-red-400 text-base font-semibold">エラー</p>
+            <p className="text-red-400 text-base font-semibold mt-1">{saveOfficeError}</p>
+          </div>
+        )}
+
+        {saveOfficeSuccess && (
+          <div className="mb-4 p-4 bg-green-900/50 border border-green-500 rounded-lg">
+            <p className="text-green-400 text-base">{saveOfficeSuccess}</p>
+          </div>
+        )}
+
+        <div className="space-y-4">
+          <div>
+            <label className="block text-slate-600 text-base font-semibold dark:text-gray-400 mb-2">
+              事業所名 <span className="text-red-400">*</span>
+            </label>
+            <input
+              type="text"
+              value={officeName}
+              onChange={(event) => onOfficeNameChange(event.target.value)}
+              className="w-full bg-white border border-slate-300 rounded-lg px-4 py-2 text-slate-900 dark:bg-gray-700 dark:border-gray-600 dark:text-white focus:outline-none focus:border-blue-500"
+              placeholder="事業所名を入力"
+              required
+              minLength={1}
+              maxLength={255}
+              disabled={isSavingOffice}
+            />
+          </div>
+
+          <div>
+            <label className="block text-slate-600 text-base font-semibold dark:text-gray-400 mb-2">事業所種別</label>
+            <select
+              value={officeType}
+              onChange={(event) => onOfficeTypeChange(event.target.value as OfficeTypeValue)}
+              className="w-full bg-white border border-slate-300 rounded-lg px-4 py-2 text-slate-900 dark:bg-gray-700 dark:border-gray-600 dark:text-white focus:outline-none focus:border-blue-500"
+              disabled={isSavingOffice}
+            >
+              <option value="transition_to_employment">移行支援</option>
+              <option value="type_A_office">就労A型</option>
+              <option value="type_B_office">就労B型</option>
+            </select>
+          </div>
+
+          <div>
+            <label className="block text-slate-600 text-base font-semibold dark:text-gray-400 mb-2">住所</label>
+            <input
+              type="text"
+              value={officeAddress}
+              onChange={(event) => onOfficeAddressChange(event.target.value)}
+              className="w-full bg-white border border-slate-300 rounded-lg px-4 py-2 text-slate-900 dark:bg-gray-700 dark:border-gray-600 dark:text-white focus:outline-none focus:border-blue-500"
+              placeholder="例: 東京都渋谷区1-2-3"
+              maxLength={500}
+              disabled={isSavingOffice}
+            />
+          </div>
+
+          <div>
+            <label className="block text-slate-600 text-base font-semibold dark:text-gray-400 mb-2">電話番号</label>
+            <input
+              type="tel"
+              value={officePhoneNumber}
+              onChange={(event) => onOfficePhoneNumberChange(event.target.value)}
+              className="w-full bg-white border border-slate-300 rounded-lg px-4 py-2 text-slate-900 dark:bg-gray-700 dark:border-gray-600 dark:text-white focus:outline-none focus:border-blue-500"
+              placeholder="例: 03-1234-5678"
+              pattern="\d{2,4}-\d{2,4}-\d{4}"
+              disabled={isSavingOffice}
+            />
+            <p className="mt-1 text-sm font-medium text-slate-500 dark:text-gray-500">
+              形式: 03-1234-5678（ハイフン区切り）
+            </p>
+          </div>
+
+          <div>
+            <label className="block text-slate-600 text-base font-semibold dark:text-gray-400 mb-2">メールアドレス</label>
+            <input
+              type="email"
+              value={officeEmail}
+              onChange={(event) => onOfficeEmailChange(event.target.value)}
+              className="w-full bg-white border border-slate-300 rounded-lg px-4 py-2 text-slate-900 dark:bg-gray-700 dark:border-gray-600 dark:text-white focus:outline-none focus:border-blue-500"
+              placeholder="例: info@example.com"
+              disabled={isSavingOffice}
+            />
+          </div>
+        </div>
+
+        <div className="flex justify-end gap-3 mt-6">
+          <button
+            onClick={onClose}
+            disabled={isSavingOffice}
+            className="bg-slate-200 hover:bg-slate-300 text-slate-900 dark:bg-gray-600 dark:hover:bg-gray-700 dark:text-white px-4 py-2 rounded-lg disabled:opacity-50 disabled:cursor-not-allowed"
+          >
+            キャンセル
+          </button>
+          <button
+            onClick={onSave}
+            disabled={isSavingOffice}
+            className="bg-blue-600 hover:bg-blue-700 text-white px-4 py-2 rounded-lg disabled:opacity-50 disabled:cursor-not-allowed flex items-center gap-2"
+          >
+            {isSavingOffice ? (
+              <>
+                <svg className="animate-spin h-4 w-4" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24">
+                  <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4"></circle>
+                  <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"></path>
+                </svg>
+                保存中...
+              </>
+            ) : (
+              '保存'
+            )}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/components/protected/admin/OfficeInfoTab.tsx
+++ b/components/protected/admin/OfficeInfoTab.tsx
@@ -1,0 +1,87 @@
+'use client';
+
+import { MdEdit, MdExitToApp } from 'react-icons/md';
+import { OfficeResponse } from '@/types/office';
+
+interface OfficeInfoTabProps {
+  office: OfficeResponse | null;
+  withdrawalSuccess: string | null;
+  onEditOffice: () => void;
+  onOpenWithdrawal: () => void;
+}
+
+export default function OfficeInfoTab({
+  office,
+  withdrawalSuccess,
+  onEditOffice,
+  onOpenWithdrawal,
+}: OfficeInfoTabProps) {
+  return (
+    <>
+      <div className="bg-white p-6 rounded-lg mb-6 border border-slate-300 shadow-sm dark:bg-gray-800 dark:border-gray-700">
+        <div className="flex items-center justify-between mb-4">
+          <h3 className="text-xl font-semibold">事業所情報</h3>
+          <button
+            onClick={onEditOffice}
+            className="flex items-center gap-2 bg-blue-600 hover:bg-blue-700 text-white px-4 py-2 rounded-lg transition-colors"
+          >
+            <MdEdit className="w-5 h-5" />
+            編集
+          </button>
+        </div>
+        <div className="space-y-3">
+          <div>
+            <p className="text-slate-600 text-base font-semibold dark:text-gray-400">事業所名</p>
+            <p className="text-slate-900 font-semibold dark:text-white">{office?.name || '未設定'}</p>
+          </div>
+          <div>
+            <p className="text-slate-600 text-base font-semibold dark:text-gray-400">事業所種別</p>
+            <p className="text-slate-900 font-semibold dark:text-white">
+              {office?.office_type === 'transition_to_employment' && '移行支援'}
+              {office?.office_type === 'type_A_office' && '就労A型'}
+              {office?.office_type === 'type_B_office' && '就労B型'}
+              {!office?.office_type && '未設定'}
+            </p>
+          </div>
+          <div>
+            <p className="text-slate-600 text-base font-semibold dark:text-gray-400">住所</p>
+            <p className="text-slate-900 font-semibold dark:text-white">{office?.address || '未設定'}</p>
+          </div>
+          <div>
+            <p className="text-slate-600 text-base font-semibold dark:text-gray-400">電話番号</p>
+            <p className="text-slate-900 font-semibold dark:text-white">{office?.phone_number || '未設定'}</p>
+          </div>
+          <div>
+            <p className="text-slate-600 text-base font-semibold dark:text-gray-400">メールアドレス</p>
+            <p className="text-slate-900 font-semibold dark:text-white">{office?.email || '未設定'}</p>
+          </div>
+        </div>
+      </div>
+
+      <div className="bg-white p-6 rounded-lg mt-6 border border-red-300 shadow-sm dark:bg-gray-800 dark:border-red-500/30">
+        <div className="flex items-center gap-3 mb-4">
+          <MdExitToApp className="w-6 h-6 text-red-400" />
+          <h3 className="text-xl font-semibold text-red-400">退会</h3>
+        </div>
+
+        {withdrawalSuccess && (
+          <div className="mb-4 p-4 bg-green-900/50 border border-green-500 rounded-lg">
+            <p className="text-green-400 text-base">{withdrawalSuccess}</p>
+          </div>
+        )}
+
+        <p className="text-slate-600 mb-4 dark:text-gray-400 text-base">
+          事務所を退会すると、事務所データと全スタッフのアカウントが削除されます。
+          退会申請後、アプリ管理者による承認が必要です。
+        </p>
+        <button
+          onClick={onOpenWithdrawal}
+          className="flex items-center gap-2 bg-red-600 hover:bg-red-700 text-white px-4 py-2 rounded-lg transition-colors"
+        >
+          <MdExitToApp className="w-5 h-5" />
+          退会を申請する
+        </button>
+      </div>
+    </>
+  );
+}

--- a/components/protected/admin/PlanTab.tsx
+++ b/components/protected/admin/PlanTab.tsx
@@ -39,7 +39,7 @@ export default function PlanTab() {
       // Stripe Checkoutページへリダイレクト
       window.location.href = url;
     } catch (err) {
-      console.error('Checkout Session作成エラー:', err);
+      console.error('Client operation failed');
       setErrorMessage(err instanceof Error ? err.message : '有料会員登録に失敗しました');
     } finally {
       setIsCreatingCheckout(false);
@@ -59,7 +59,7 @@ export default function PlanTab() {
         refreshBillingStatus();
       }, 3000);
     } catch (err) {
-      console.error('Portal Session作成エラー:', err);
+      console.error('Client operation failed');
       setErrorMessage(err instanceof Error ? err.message : '有料会員管理画面の表示に失敗しました');
     } finally {
       setIsCreatingPortal(false);

--- a/components/protected/admin/StaffManagementTab.tsx
+++ b/components/protected/admin/StaffManagementTab.tsx
@@ -1,0 +1,310 @@
+'use client';
+
+import { AiOutlineQuestionCircle } from 'react-icons/ai';
+import { MdCancel, MdCheckCircle, MdDelete } from 'react-icons/md';
+import { StaffResponse } from '@/types/staff';
+
+interface StaffManagementTabProps {
+  officeStaffs: StaffResponse[];
+  isLoadingStaffs: boolean;
+  loadStaffsError: string | null;
+  staffMfaTogglingId: string | null;
+  staffDeletingId: string | null;
+  isBulkMfaProcessing: boolean;
+  bulkMfaError: string | null;
+  bulkMfaSuccess: string | null;
+  showBulkMfaResultModal: boolean;
+  onBulkEnableMfa: () => void;
+  onBulkDisableMfa: () => void;
+  onStaffMfaEnable: (staff: StaffResponse) => void;
+  onStaffMfaDisable: (staff: StaffResponse) => void;
+  onStaffDelete: (staff: StaffResponse) => void;
+  calculateRemainingDays: (deletedAt: string | null) => number;
+  getRoleBadgeColor: (role: string) => string;
+  getRoleLabel: (role: string) => string;
+}
+
+export default function StaffManagementTab({
+  officeStaffs,
+  isLoadingStaffs,
+  loadStaffsError,
+  staffMfaTogglingId,
+  staffDeletingId,
+  isBulkMfaProcessing,
+  bulkMfaError,
+  bulkMfaSuccess,
+  showBulkMfaResultModal,
+  onBulkEnableMfa,
+  onBulkDisableMfa,
+  onStaffMfaEnable,
+  onStaffMfaDisable,
+  onStaffDelete,
+  calculateRemainingDays,
+  getRoleBadgeColor,
+  getRoleLabel,
+}: StaffManagementTabProps) {
+  return (
+    <div className="bg-white p-6 rounded-lg mb-6 border border-slate-300 shadow-sm dark:bg-gray-800 dark:border-gray-700">
+      <div className="flex items-center justify-between mb-4">
+        <div className="flex items-center gap-3">
+          <h3 className="text-xl font-semibold">事務所スタッフ管理</h3>
+          <span className="text-slate-600 text-base font-semibold dark:text-gray-400">
+            {officeStaffs.length}名
+          </span>
+
+          <div className="group relative">
+            <button className="text-blue-400 hover:text-blue-300 text-base font-semibold flex items-center gap-1 transition-colors">
+              <AiOutlineQuestionCircle className="h-5 w-5" />
+              <span className="underline">QRコードを紛失した場合</span>
+            </button>
+            <div className="absolute left-0 top-full mt-2 w-80 bg-white border border-slate-300 dark:bg-gray-900 dark:border-gray-700 rounded-lg p-4 shadow-xl opacity-0 invisible group-hover:opacity-100 group-hover:visible transition-all duration-200 z-50">
+              <div className="flex items-start gap-2">
+                <AiOutlineQuestionCircle className="h-5 w-5 text-blue-400 flex-shrink-0 mt-0.5" />
+                <div>
+                  <p className="text-base font-semibold text-slate-900 dark:text-white mb-2">QRコード紛失時の対処法</p>
+                  <ol className="text-base text-slate-700 dark:text-gray-300 space-y-2 list-decimal list-inside">
+                    <li>対象スタッフの２段階認証を一度無効化する</li>
+                    <li>再度２段階認証を有効化する</li>
+                    <li>新しいQRコードとシークレットキーが発行される</li>
+                    <li>スタッフに新しいQRコードを共有する</li>
+                  </ol>
+                  <p className="text-sm font-medium text-slate-500 dark:text-gray-400 mt-3">
+                    ⚠️ 無効化すると、既存のTOTPアプリの設定は使用できなくなります。
+                  </p>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+        <div className="flex gap-2">
+          <button
+            onClick={onBulkEnableMfa}
+            disabled={isBulkMfaProcessing || isLoadingStaffs}
+            className="bg-green-600 hover:bg-green-700 text-white px-4 py-2 rounded-lg text-base font-semibold disabled:bg-gray-600 disabled:cursor-not-allowed flex items-center gap-2 transition-colors"
+          >
+            {isBulkMfaProcessing ? (
+              <>
+                <SpinnerIcon />
+                処理中...
+              </>
+            ) : (
+              <>
+                <MdCheckCircle className="w-5 h-5" />
+                全員２段階認証有効化
+              </>
+            )}
+          </button>
+          <button
+            onClick={onBulkDisableMfa}
+            disabled={isBulkMfaProcessing || isLoadingStaffs}
+            className="bg-red-600 hover:bg-red-700 text-white px-4 py-2 rounded-lg text-base font-semibold disabled:bg-gray-600 disabled:cursor-not-allowed flex items-center gap-2 transition-colors"
+          >
+            {isBulkMfaProcessing ? (
+              <>
+                <SpinnerIcon />
+                処理中...
+              </>
+            ) : (
+              <>
+                <MdCancel className="w-5 h-5" />
+                全員２段階認証無効化
+              </>
+            )}
+          </button>
+        </div>
+      </div>
+
+      {bulkMfaError && (
+        <div className="mb-4 p-4 bg-red-900/50 border border-red-500 rounded-lg">
+          <p className="text-red-400 text-base font-semibold">エラー</p>
+          <p className="text-red-400 text-base font-semibold mt-1">{bulkMfaError}</p>
+        </div>
+      )}
+
+      {bulkMfaSuccess && !showBulkMfaResultModal && (
+        <div className="mb-4 p-4 bg-green-900/50 border border-green-500 rounded-lg">
+          <p className="text-green-400 text-base font-semibold">成功</p>
+          <p className="text-green-400 text-base font-semibold mt-1">{bulkMfaSuccess}</p>
+        </div>
+      )}
+
+      {isLoadingStaffs && (
+        <div className="p-4 bg-slate-100 border border-slate-300 rounded-lg flex dark:bg-gray-700 dark:border-gray-600 items-center">
+          <SpinnerIcon className="h-5 w-5 text-blue-400 mr-3" />
+          <p className="text-slate-600 text-base font-semibold dark:text-gray-400">スタッフ一覧を読み込み中...</p>
+        </div>
+      )}
+
+      {loadStaffsError && !isLoadingStaffs && (
+        <div className="p-4 bg-red-900/50 border border-red-500 rounded-lg">
+          <p className="text-red-400 text-base font-semibold">読み込みエラー</p>
+          <p className="text-red-400 text-base font-semibold mt-1">{loadStaffsError}</p>
+        </div>
+      )}
+
+      {!isLoadingStaffs && !loadStaffsError && (
+        <div className="overflow-x-auto">
+          <table className="w-full">
+            <thead>
+              <tr className="border-b border-slate-300 dark:border-gray-700">
+                <th className="text-left py-3 px-4 text-slate-600 dark:text-gray-400 font-semibold">氏名</th>
+                <th className="text-left py-3 px-4 text-slate-600 dark:text-gray-400 font-semibold">メールアドレス</th>
+                <th className="text-left py-3 px-4 text-slate-600 dark:text-gray-400 font-semibold">役割</th>
+                <th className="text-left py-3 px-4 text-slate-600 dark:text-gray-400 font-semibold">
+                  <div className="flex items-center gap-2">
+                    ２段階認証状態/変更
+                    <div className="relative group/help">
+                      <button
+                        type="button"
+                        className="w-4 h-4 rounded-full bg-slate-200 hover:bg-slate-300 text-slate-700 dark:bg-gray-700/50 dark:hover:bg-gray-600/70 dark:text-gray-300 flex items-center justify-center text-sm font-bold transition-colors"
+                        title="２段階認証について"
+                      >
+                        ?
+                      </button>
+                      <div className="absolute left-0 top-full mt-2 w-80 bg-white border border-slate-300 dark:bg-gray-900 dark:border-gray-700 rounded-lg p-4 shadow-xl opacity-0 invisible group-hover/help:opacity-100 group-hover/help:visible transition-all duration-200 z-50">
+                        <div className="flex items-start gap-2">
+                          <svg className="w-5 h-5 text-blue-400 flex-shrink-0 mt-0.5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
+                          </svg>
+                          <div>
+                            <p className="text-base font-semibold text-slate-900 dark:text-white mb-2">２段階認証とは</p>
+                            <p className="text-base text-slate-700 dark:text-gray-300 leading-relaxed mb-3">
+                              ２段階認証は、パスワードに加えて、スマートフォンアプリで生成される6桁の認証コードを使用する認証方式です。
+                            </p>
+                            <ul className="text-base text-slate-700 dark:text-gray-300 space-y-1 list-disc list-inside">
+                              <li>セキュリティが大幅に向上します</li>
+                              <li>Google Authenticatorなどのアプリが必要です</li>
+                              <li>ログイン時に追加の認証コード入力が必要になります</li>
+                            </ul>
+                          </div>
+                        </div>
+                      </div>
+                    </div>
+                  </div>
+                </th>
+                <th className="text-left py-3 px-4 text-slate-600 dark:text-gray-400 font-semibold">スタッフ削除</th>
+              </tr>
+            </thead>
+            <tbody>
+              {officeStaffs.map((staff) => {
+                const isDeleted = staff.is_deleted;
+                const remainingDays = isDeleted ? calculateRemainingDays(staff.deleted_at) : 0;
+
+                return (
+                  <tr key={staff.id} className={`border-b border-slate-300 dark:border-gray-700 hover:bg-slate-100 dark:hover:bg-gray-700/50 ${isDeleted ? 'opacity-50' : ''}`}>
+                    <td className="py-3 px-4">
+                      <div className="flex items-center gap-2">
+                        <span className={isDeleted ? 'text-slate-500 dark:text-gray-500 line-through' : 'text-slate-900 dark:text-white'}>
+                          {staff.full_name}
+                        </span>
+                        {isDeleted && (
+                          <span className="px-2 py-1 rounded-lg text-sm font-semibold bg-red-900/50 text-red-400 border border-red-500">
+                            削除済み - 残り{remainingDays}日で完全削除
+                          </span>
+                        )}
+                      </div>
+                    </td>
+                    <td className="py-3 px-4 text-slate-700 dark:text-gray-300">{staff.email}</td>
+                    <td className="py-3 px-4">
+                      <span
+                        className={`inline-flex min-w-20 justify-center rounded border px-3 py-1 text-base font-semibold ${getRoleBadgeColor(staff.role)}`}
+                      >
+                        {getRoleLabel(staff.role)}
+                      </span>
+                    </td>
+                    <td className="py-3 px-4">
+                      <div className="flex items-center gap-2 group">
+                        <span
+                          className={`inline-flex min-w-20 justify-center rounded border px-3 py-1 text-base font-semibold items-center gap-1 ${
+                            staff.is_mfa_enabled
+                              ? 'border-green-500 text-green-700 dark:text-green-300'
+                              : 'border-slate-400 text-slate-600 dark:border-gray-500 dark:text-gray-300'
+                          }`}
+                        >
+                          {staff.is_mfa_enabled ? (
+                            <>
+                              <MdCheckCircle className="w-4 h-4" />
+                              有効
+                            </>
+                          ) : (
+                            <>
+                              <MdCancel className="w-4 h-4" />
+                              無効
+                            </>
+                          )}
+                        </span>
+                        {staff.is_mfa_enabled ? (
+                          <button
+                            onClick={() => onStaffMfaDisable(staff)}
+                            disabled={staffMfaTogglingId === staff.id || isDeleted}
+                            className="opacity-0 group-hover:opacity-100 transition-opacity bg-red-600 hover:bg-red-700 text-white px-3 py-1 rounded text-base font-semibold disabled:bg-gray-600 disabled:cursor-not-allowed flex items-center gap-1"
+                          >
+                            {staffMfaTogglingId === staff.id ? (
+                              <>
+                                <SpinnerIcon />
+                                処理中...
+                              </>
+                            ) : (
+                              '無効化'
+                            )}
+                          </button>
+                        ) : (
+                          <button
+                            onClick={() => onStaffMfaEnable(staff)}
+                            disabled={staffMfaTogglingId === staff.id || isDeleted}
+                            className="opacity-0 group-hover:opacity-100 transition-opacity bg-blue-600 hover:bg-blue-700 text-white px-3 py-1 rounded text-base font-semibold disabled:bg-gray-600 disabled:cursor-not-allowed flex items-center gap-1"
+                          >
+                            {staffMfaTogglingId === staff.id ? (
+                              <>
+                                <SpinnerIcon />
+                                処理中...
+                              </>
+                            ) : (
+                              '有効化'
+                            )}
+                          </button>
+                        )}
+                      </div>
+                    </td>
+                    <td className="py-3 px-4">
+                      {isDeleted ? (
+                        <span className="text-slate-500 dark:text-gray-500 text-base">削除済み</span>
+                      ) : (
+                        <button
+                          onClick={() => onStaffDelete(staff)}
+                          disabled={staffDeletingId === staff.id}
+                          className="bg-red-600 hover:bg-red-700 text-white px-3 py-1 rounded text-base font-semibold disabled:bg-gray-600 disabled:cursor-not-allowed flex items-center gap-1"
+                        >
+                          {staffDeletingId === staff.id ? (
+                            <>
+                              <SpinnerIcon />
+                              削除中...
+                            </>
+                          ) : (
+                            <>
+                              <MdDelete className="w-4 h-4" />
+                              削除
+                            </>
+                          )}
+                        </button>
+                      )}
+                    </td>
+                  </tr>
+                );
+              })}
+            </tbody>
+          </table>
+        </div>
+      )}
+    </div>
+  );
+}
+
+function SpinnerIcon({ className = 'animate-spin h-4 w-4' }: { className?: string }) {
+  return (
+    <svg className={className} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24">
+      <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4"></circle>
+      <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"></path>
+    </svg>
+  );
+}

--- a/components/protected/app-admin/AppAdminDashboard.tsx
+++ b/components/protected/app-admin/AppAdminDashboard.tsx
@@ -29,7 +29,7 @@ export default function AppAdminDashboard({ staff }: AppAdminDashboardProps) {
       await authApi.logout();
       router.push('/auth/app-admin/login');
     } catch (error) {
-      console.error('ログアウトに失敗しました:', error);
+      console.error('Client operation failed');
     } finally {
       setIsLoggingOut(false);
     }

--- a/components/protected/app-admin/InquiryReplyModal.tsx
+++ b/components/protected/app-admin/InquiryReplyModal.tsx
@@ -44,7 +44,7 @@ export default function InquiryReplyModal({
       onSuccess();
       onClose();
     } catch (error) {
-      console.error('❌ [InquiryReplyModal] 返信送信失敗:', error);
+      console.error('Client operation failed');
       const message = error instanceof Error ? error.message : String(error);
       toast.error(message || '返信の送信に失敗しました');
     } finally {

--- a/components/protected/dashboard/Dashboard.tsx
+++ b/components/protected/dashboard/Dashboard.tsx
@@ -3,14 +3,6 @@
 import Link from 'next/link';
 import { useState, useEffect, useMemo, useCallback, useRef } from 'react';
 import { useRouter, useSearchParams } from 'next/navigation';
-import { dashboardApi, DashboardParams } from '@/lib/dashboard';
-import { welfareRecipientsApi } from '@/lib/welfare-recipients';
-import { DashboardData } from '@/types/dashboard';
-import { authApi } from '@/lib/auth';
-import { StaffResponse } from '@/types/staff';
-import { billingApi } from '@/lib/api/billing';
-import { canWriteWithBillingStatus, getBillingRestrictionReason } from '@/lib/billing/status';
-import { BillingStatusResponse } from '@/types/billing';
 import MfaPrompt from '@/components/auth/MfaPrompt';
 import { SmartDropdown } from '@/components/ui/smart-dropdown';
 import { DropdownMenuItem, DropdownMenuSeparator } from '@/components/ui/dropdown-menu';
@@ -20,33 +12,27 @@ import { useStaffRole } from '@/hooks/useStaffRole';
 import { ActionType, ResourceType } from '@/types/employeeActionRequest';
 import { toast } from '@/lib/toast-debug';
 import { ActiveFilters } from './ActiveFilters';
+import { canEditDashboard, buildBillingRestrictionWarning } from '@/lib/permissions/dashboard';
+import { useDashboardData } from '@/hooks/dashboard/useDashboardData';
+import { useDashboardFilters } from '@/hooks/dashboard/useDashboardFilters';
 
 // UI設計意図: 30〜60代の福祉職員向けに、主要情報はtext-base以上、操作はアイコン依存を避けた文字ボタンで表示する。
 // 変更概要: 期限・氏名・操作ボタンを拡大し、期限超過/絞り込み/並び替えを文字で判断できるようにした。
 export default function Dashboard() {
-  const [dashboardData, setDashboardData] = useState<DashboardData | null>(null);
-  const [staff, setStaff] = useState<StaffResponse | null>(null);
-  const [billingStatus, setBillingStatus] = useState<BillingStatusResponse | null>(null);
   const router = useRouter();
   const searchParams = useSearchParams();
-  const [sortOrder, setSortOrder] = useState<'asc' | 'desc'>('asc');
-  const [sortBy, setSortBy] = useState('next_renewal_deadline');
-  const [searchTerm, setSearchTerm] = useState('');
-  const [isLoading, setIsLoading] = useState(false);
-  const isLoadingRef = useRef(isLoading);
   const messageShownRef = useRef(false); // メッセージ表示済みフラグ
-  const [debouncedSearchTerm, setDebouncedSearchTerm] = useState('');
-  const [activeFilters, setActiveFilters] = useState<{
-    isOverdue: boolean;
-    isUpcoming: boolean;
-    hasAssessmentDue: boolean;
-    status: string | null;
-  }>({
-    isOverdue: false,
-    isUpcoming: false,
-    hasAssessmentDue: false,
-    status: null,
-  });
+  const {
+    dashboardData,
+    staff,
+    billingStatus,
+    isLoading,
+    isLoadingRef,
+    applyFilters,
+    fetchInitialData,
+    resetDashboardData,
+    deleteRecipient,
+  } = useDashboardData();
 
   // Employee Action Request Modal state
   const [isRequestModalOpen, setIsRequestModalOpen] = useState(false);
@@ -57,81 +43,37 @@ export default function Dashboard() {
 
   const { isEmployee } = useStaffRole();
 
-  // 編集可能かどうかの判定: MFA有効 かつ 課金ステータスが書き込み可能
-  const canEdit = useMemo(() => {
-    if (!staff || !billingStatus) return false;
+  const canEdit = useMemo(
+    () => canEditDashboard(staff, billingStatus),
+    [staff, billingStatus]
+  );
 
-    return staff.is_mfa_enabled && canWriteWithBillingStatus(billingStatus);
-  }, [staff, billingStatus]);
-
-  const billingRestrictionReason = useMemo(
-    () => getBillingRestrictionReason(billingStatus),
+  const billingRestrictionWarning = useMemo(
+    () => buildBillingRestrictionWarning(billingStatus),
     [billingStatus]
   );
 
-  const billingRestrictionWarning = (() => {
-    switch (billingRestrictionReason) {
-      case 'trial_expired':
-        return {
-          title: '無料試用期間が終了しているため利用できません',
-          body: '新規作成・編集・削除などの操作はご利用いただけません。オーナーの方は管理者設定の有料会員ページから有料会員に登録してください。',
-        };
-      case 'payment_failed':
-        return {
-          title: '有料会員料金のお支払いが失敗しているため利用できません',
-          body: '新規作成・編集・削除などの操作はご利用いただけません。オーナーの方は管理者設定の有料会員ページから支払い方法を更新してください。',
-        };
-      case 'past_due':
-        return {
-          title: 'お支払いの確認が必要なため利用できません',
-          body: '新規作成・編集・削除などの操作はご利用いただけません。オーナーの方は管理者設定の有料会員ページを確認してください。',
-        };
-      case 'canceled':
-        return {
-          title: '有料会員登録がキャンセル済みのため利用できません',
-          body: '新規作成・編集・削除などの操作はご利用いただけません。オーナーの方は管理者設定の有料会員ページから再度入会してください。',
-        };
-      default:
-        return null;
-    }
-  })();
+  const {
+    activeFilters,
+    searchTerm,
+    hasActiveDashboardFilter,
+    handleNextRenewalSortClick,
+    handleNameSortClick,
+    getSortButtonLabel,
+    handleSearch,
+    handleFilterToggle,
+    handleStatusFilter,
+    handleFilterRemove,
+    handleClearAllFilters,
+    resetFiltersForDisplayReset,
+  } = useDashboardFilters({
+    initialDeadlineAlert: searchParams.get('filter') === 'deadline_alert',
+    onApplyFilters: applyFilters,
+  });
 
   useEffect(() => {
-    isLoadingRef.current = isLoading;
-  }, [isLoading]);
-
-  useEffect(() => {
-    const fetchInitialData = async () => {
-      try {
-        const [userData, data, billing] = await Promise.all([
-          authApi.getCurrentUser(),
-          dashboardApi.getDashboardData(),
-          billingApi.getBillingStatus()
-        ]);
-        setStaff(userData);
-        setDashboardData(data);
-        setBillingStatus(billing);
-      } catch (error) {
-        console.error('Failed to fetch initial data:', error);
-      }
-    };
-
     fetchInitialData();
-  }, []);
-
-  // クエリパラメータのfilterを読み取ってフィルターを設定
-  useEffect(() => {
-    const filter = searchParams.get('filter');
-    if (filter === 'deadline_alert') {
-      // 期限が近い利用者のみを表示するフィルター
-      setActiveFilters({
-        isOverdue: false,
-        isUpcoming: true,
-        hasAssessmentDue: false,
-        status: null,
-      });
-    }
-  }, [searchParams]);
+  }, [fetchInitialData]);
 
   // クエリパラメータからメッセージを読み取ってtoastを表示
   useEffect(() => {
@@ -172,178 +114,15 @@ export default function Dashboard() {
     url.searchParams.delete('hotbar_type');
     window.history.replaceState({}, '', url.toString());
   }, [searchParams]);
-
-
-
-
-  const handleNextRenewalSortClick = () => {
-    const newSortOrder = sortBy === 'next_renewal_deadline' && sortOrder === 'asc' ? 'desc' : 'asc';
-    setSortBy('next_renewal_deadline');
-    setSortOrder(newSortOrder);
-    applyFilters({
-      sortBy: 'next_renewal_deadline',
-      sortOrder: newSortOrder,
-      is_overdue: activeFilters.isOverdue,
-      is_upcoming: activeFilters.isUpcoming,
-      has_assessment_due: activeFilters.hasAssessmentDue,
-      status: activeFilters.status || undefined,
-    });
-  };
-
-  const handleNameSortClick = () => {
-    const newSortOrder = sortBy === 'name_phonetic' && sortOrder === 'asc' ? 'desc' : 'asc';
-    setSortBy('name_phonetic');
-    setSortOrder(newSortOrder);
-    applyFilters({
-      sortBy: 'name_phonetic',
-      sortOrder: newSortOrder,
-      is_overdue: activeFilters.isOverdue,
-      is_upcoming: activeFilters.isUpcoming,
-      has_assessment_due: activeFilters.hasAssessmentDue,
-      status: activeFilters.status || undefined,
-    });
-  };
-
-  const getSortButtonLabel = (targetSortBy: string) => {
-    if (sortBy !== targetSortBy) return '昇順';
-    return sortOrder === 'asc' ? '降順' : '昇順';
-  };
-
-  const handleSearch = useCallback(async (term: string) => {
-    setSearchTerm(term);
-    // デバウンス処理に委譲するため、ここでは即座にAPIは呼ばない
-  }, []);
-
-  const applyFilters = useCallback(async (params: Partial<DashboardParams> = {}) => {
-    if (isLoadingRef.current) return;
-    try {
-      setIsLoading(true);
-      const filterParams: DashboardParams = {
-        searchTerm: searchTerm,
-        sortBy: params.sortBy ?? sortBy,
-        sortOrder: (params.sortOrder as 'asc'|'desc') ?? sortOrder,
-        ...params,
-      };
-
-      const newDashboardData = await dashboardApi.getDashboardData(filterParams);
-
-      // recipients を必ず配列にする（API の不整合や null を防ぐ）
-      if (newDashboardData) {
-        if (!Array.isArray(newDashboardData.recipients)) {
-          console.warn('dashboardApi returned recipients not array:', newDashboardData.recipients);
-          // 安全のため空配列で初期化
-          // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-          // @ts-ignore
-          newDashboardData.recipients = Array.isArray(newDashboardData.recipients) ? newDashboardData.recipients : [];
-        }
-      }
-      setDashboardData(newDashboardData);
-    } catch (error) {
-      console.error('Failed to apply filters:', error);
-    } finally {
-      setIsLoading(false);
-    }
-  }, [searchTerm, sortOrder, sortBy]);
-
-  // フィルタ切替ハンドラ（applyFilters を先に宣言していることが前提）
-  const handleFilterToggle = useCallback((filterType: 'isOverdue' | 'isUpcoming' | 'hasAssessmentDue', value: boolean) => {
-    setActiveFilters((prev) => {
-      const newFilters = { ...prev, [filterType]: value };
-      // 非同期呼び出しだが UI 側の状態更新は即時に行う -> エラー無視で発火
-      void applyFilters({
-        is_overdue: newFilters.isOverdue,
-        is_upcoming: newFilters.isUpcoming,
-        has_assessment_due: newFilters.hasAssessmentDue,
-        status: newFilters.status || undefined,
-      });
-      return newFilters;
-    });
-  }, [applyFilters]);
-
-  const handleStatusFilter = useCallback((status: string | null) => {
-    setActiveFilters((prev) => {
-      const newFilters = { ...prev, status };
-      void applyFilters({
-        is_overdue: newFilters.isOverdue,
-        is_upcoming: newFilters.isUpcoming,
-        has_assessment_due: newFilters.hasAssessmentDue,
-        status: status || undefined,
-      });
-      return newFilters;
-    });
-  }, [applyFilters]);
-
-  // フィルターを個別に解除
-  const handleFilterRemove = useCallback((filterKey: string) => {
-    if (filterKey === 'search') {
-      setSearchTerm('');
-      setDebouncedSearchTerm('');
-    } else {
-      setActiveFilters((prev) => {
-        const newFilters = { ...prev };
-        if (filterKey === 'status') {
-          newFilters.status = null;
-        } else {
-          // isOverdue, isUpcoming, hasAssessmentDue
-          (newFilters as Record<string, unknown>)[filterKey] = false;
-        }
-        void applyFilters({
-          is_overdue: newFilters.isOverdue,
-          is_upcoming: newFilters.isUpcoming,
-          has_assessment_due: newFilters.hasAssessmentDue,
-          status: newFilters.status || undefined,
-        });
-        return newFilters;
-      });
-    }
-  }, [applyFilters]);
-
-  // すべてのフィルターをクリア
-  const handleClearAllFilters = useCallback(() => {
-    setSearchTerm('');
-    setDebouncedSearchTerm('');
-    setActiveFilters({
-      isOverdue: false,
-      isUpcoming: false,
-      hasAssessmentDue: false,
-      status: null,
-    });
-    void applyFilters({
-      is_overdue: false,
-      is_upcoming: false,
-      has_assessment_due: false,
-      status: undefined,
-    });
-  }, [applyFilters]);
-
   const handleResetDisplay = useCallback(async () => {
     if (isLoadingRef.current) return;
-    setSearchTerm('');
-    setDebouncedSearchTerm('');
-    setSortBy('name_phonetic');
-    setSortOrder('asc');
-    setActiveFilters({
-      isOverdue: false,
-      isUpcoming: false,
-      hasAssessmentDue: false,
-      status: null,
-    });
+    resetFiltersForDisplayReset();
 
     try {
-      setIsLoading(true);
-      const resetData = await dashboardApi.getDashboardData();
-      if (resetData) {
-        if (!Array.isArray(resetData.recipients)) {
-          resetData.recipients = Array.isArray(resetData.recipients) ? resetData.recipients : [];
-        }
-      }
-      setDashboardData(resetData);
-    } catch (error) {
-      console.error('Failed to reset display:', error);
-    } finally {
-      setIsLoading(false);
+      await resetDashboardData();
+    } catch {
     }
-  }, []);
+  }, [isLoadingRef, resetDashboardData, resetFiltersForDisplayReset]);
 
   const handleDeleteRecipient = useCallback(async (recipientId: string, recipientName: string) => {
     // Employeeの場合はリクエスト申請モーダルを表示
@@ -355,33 +134,14 @@ export default function Dashboard() {
 
     // Manager/Ownerの場合は従来通り削除確認
     if (window.confirm(`${recipientName}を本当に削除しますか？この操作は元に戻せません。`)) {
-      try {
-        setIsLoading(true);
-
-        // APIを呼び出してバックエンドのデータを削除
-        await welfareRecipientsApi.delete(recipientId);
-
-        // フロントエンドの状態を直接更新してUIから即座に削除
-        setDashboardData(prevData => {
-          if (!prevData) return null;
-          const updatedRecipients = prevData.recipients.filter(
-            recipient => recipient.id !== recipientId
-          );
-          return { ...prevData, recipients: updatedRecipients };
-        });
-
-        // 削除成功をtoastで通知
+      const deleted = await deleteRecipient(recipientId);
+      if (deleted) {
         toast.success(`${recipientName}を削除しました`);
-
-      } catch (error) {
-        console.error('Failed to delete recipient:', error);
-        // toastでエラー通知
+      } else {
         toast.error('利用者の削除に失敗しました。ページをリロードして再度お試しください。');
-      } finally {
-        setIsLoading(false);
       }
     }
-  }, [isEmployee]);
+  }, [deleteRecipient, isEmployee]);
 
   const handleRequestSuccess = () => {
     // リクエスト送信成功時の処理
@@ -451,16 +211,6 @@ export default function Dashboard() {
     [dashboardData]
   );
 
-  const hasActiveDashboardFilter = useMemo(
-    () =>
-      Boolean(searchTerm) ||
-      activeFilters.isOverdue ||
-      activeFilters.isUpcoming ||
-      activeFilters.hasAssessmentDue ||
-      Boolean(activeFilters.status),
-    [activeFilters, searchTerm]
-  );
-
   const emptyState = useMemo(() => {
     if (serviceRecipients.length > 0) return null;
 
@@ -501,23 +251,6 @@ export default function Dashboard() {
     serviceRecipients.length,
   ]);
   
-  // 検索デバウンス（300ms）
-  useEffect(() => {
-    const timer = setTimeout(() => {
-      setDebouncedSearchTerm(searchTerm);
-    }, 300);
-
-    return () => clearTimeout(timer);
-  }, [searchTerm]);
-
-  // デバウンスされた検索実行
-  useEffect(() => {
-    if (debouncedSearchTerm !== searchTerm) return;
-    if (debouncedSearchTerm) {
-      applyFilters({ searchTerm: debouncedSearchTerm });
-    }
-  }, [debouncedSearchTerm, applyFilters, searchTerm]);
-
   // カウント計算のメモ化
   const { expiredCount, nearDeadlineCount, assessmentDueCount } = useMemo(() => {
     return serviceRecipients.reduce(

--- a/components/protected/pdf-list/PdfViewContent.tsx
+++ b/components/protected/pdf-list/PdfViewContent.tsx
@@ -100,7 +100,7 @@ export default function PdfViewContent({
           (a.last_name + a.first_name).localeCompare(b.last_name + b.first_name, 'ja')
         ));
       } catch (err) {
-        console.error('Failed to fetch recipients:', err);
+        console.error('Client operation failed');
       }
     };
 
@@ -135,7 +135,7 @@ export default function PdfViewContent({
         setPdfs(response.items);
         setTotal(response.total);
       } catch (err) {
-        console.error('Failed to fetch PDFs:', err);
+        console.error('Client operation failed');
         setError('PDF一覧の取得に失敗しました');
       } finally {
         setIsLoading(false);

--- a/components/protected/profile/NotificationSettings.tsx
+++ b/components/protected/profile/NotificationSettings.tsx
@@ -47,7 +47,7 @@ export default function NotificationSettings() {
       );
       setPreferences(data);
     } catch (error) {
-      console.error('Failed to fetch notification preferences:', error);
+      console.error('Client operation failed');
     } finally {
       setIsLoading(false);
     }
@@ -64,7 +64,7 @@ export default function NotificationSettings() {
       setPreferences(data);
       toast.success('通知設定を保存しました');
     } catch (error) {
-      console.error('Failed to save notification preferences:', error);
+      console.error('Client operation failed');
       toast.error(error instanceof Error ? error.message : '設定の保存に失敗しました');
     } finally {
       setIsSaving(false);
@@ -112,7 +112,7 @@ export default function NotificationSettings() {
           await savePreferences(newPreferences);
           toast.success('プッシュ通知を有効にしました');
         } catch (error) {
-          console.error('Failed to subscribe:', error);
+          console.error('Client operation failed');
           toast.error(getErrorMessage(error));
         }
       } else {
@@ -121,7 +121,7 @@ export default function NotificationSettings() {
           await savePreferences(newPreferences);
           toast.success('プッシュ通知を無効にしました');
         } catch (error) {
-          console.error('Failed to unsubscribe:', error);
+          console.error('Client operation failed');
           toast.error(getErrorMessage(error));
         }
       }

--- a/components/protected/profile/Profile.tsx
+++ b/components/protected/profile/Profile.tsx
@@ -47,7 +47,7 @@ export default function Profile({ staff: initialStaff }: ProfileProps) {
         const officeData = await officeApi.getMyOffice();
         setOffice(officeData);
       } catch (error) {
-        console.error('事業所情報の取得に失敗しました:', error);
+        console.error('Client operation failed');
       }
     };
     fetchOffice();

--- a/components/protected/recipients/EmploymentSection.tsx
+++ b/components/protected/recipients/EmploymentSection.tsx
@@ -81,7 +81,7 @@ export default function EmploymentSection({
       setShowModal(false);
       onRefresh();
     } catch (err) {
-      console.error('Failed to save employment:', err);
+      console.error('Client operation failed');
       if (err instanceof Error) {
         setError(err.message);
       } else {

--- a/components/protected/recipients/RecipientEditForm.tsx
+++ b/components/protected/recipients/RecipientEditForm.tsx
@@ -3,168 +3,19 @@
 import { useState, useEffect } from 'react';
 import { useRouter } from 'next/navigation';
 import { welfareRecipientsApi, transformFormDataToBackend, type WelfareRecipient } from '@/lib/welfare-recipients';
-import DateDrumPicker from '@/components/ui/DateDrumPicker';
 import EmployeeActionRequestModal from '@/components/common/EmployeeActionRequestModal';
 import { useStaffRole } from '@/hooks/useStaffRole';
 import { ActionType, ResourceType } from '@/types/employeeActionRequest';
-
-// Basic Information Section
-interface BasicInfoData {
-  firstName: string;
-  lastName: string;
-  firstNameFurigana: string;
-  lastNameFurigana: string;
-  birthDay: string;
-  gender: string;
-}
-
-// Contact & Address Information Section
-interface ContactAddressData {
-  address: string;
-  formOfResidence: string;
-  formOfResidenceOtherText?: string;
-  meansOfTransportation: string;
-  meansOfTransportationOtherText?: string;
-  tel: string;
-}
-
-// Emergency Contact Information
-interface EmergencyContactData {
-  firstName: string;
-  lastName: string;
-  firstNameFurigana: string;
-  lastNameFurigana: string;
-  relationship: string;
-  tel: string;
-  address?: string;
-  notes?: string;
-  priority: number;
-}
-
-// Disability & Disease Information Section
-interface DisabilityInfoData {
-  disabilityOrDiseaseName: string;
-  livelihoodProtection: string;
-  specialRemarks?: string;
-}
-
-// Disability Detail Information
-interface DisabilityDetailData {
-  category: string;
-  gradeOrLevel?: string;
-  physicalDisabilityType?: string;
-  physicalDisabilityTypeOtherText?: string;
-  applicationStatus: string;
-}
-
-interface FormData {
-  basicInfo: BasicInfoData;
-  contactAddress: ContactAddressData;
-  emergencyContacts: EmergencyContactData[];
-  disabilityInfo: DisabilityInfoData;
-  disabilityDetails: DisabilityDetailData[];
-}
-
-// Enum options for dropdowns
-const GENDER_OPTIONS = [
-  { value: 'male', label: '男性' },
-  { value: 'female', label: '女性' },
-  { value: 'other', label: 'その他' },
-];
-
-const FORM_OF_RESIDENCE_OPTIONS = [
-  { value: 'home_with_family', label: '自宅（家族と同居）' },
-  { value: 'home_alone', label: '自宅（一人暮らし）' },
-  { value: 'group_home', label: 'グループホーム' },
-  { value: 'institution', label: '入所施設' },
-  { value: 'hospital', label: '病院・医療機関' },
-  { value: 'other', label: 'その他' },
-];
-
-const MEANS_OF_TRANSPORTATION_OPTIONS = [
-  { value: 'walk', label: '徒歩' },
-  { value: 'bicycle', label: '自転車' },
-  { value: 'motorbike', label: 'バイク・原付' },
-  { value: 'car_self', label: '自家用車（自分で運転）' },
-  { value: 'car_transport', label: '自家用車（送迎）' },
-  { value: 'public_transport', label: '公共交通機関（電車・バス）' },
-  { value: 'welfare_transport', label: '福祉輸送サービス' },
-  { value: 'other', label: 'その他' },
-];
-
-const LIVELIHOOD_PROTECTION_OPTIONS = [
-  { value: 'not_receiving', label: 'なし' },
-  { value: 'receiving_with_allowance', label: 'あり（他人介護料有り）' },
-  { value: 'receiving_without_allowance', label: 'あり（他人介護料無し）' },
-  { value: 'applying', label: '申請中' },
-  { value: 'planning', label: '申請予定' },
-];
-
-const DISABILITY_CATEGORY_OPTIONS = [
-  { value: 'physical_handbook', label: '身体障害者手帳' },
-  { value: 'intellectual_handbook', label: '療育手帳' },
-  { value: 'mental_health_handbook', label: '精神障害者保健福祉手帳' },
-  { value: 'disability_basic_pension', label: '障害基礎年金' },
-  { value: 'other_disability_pension', label: 'その他の障害年金' },
-  { value: 'public_assistance', label: '生活保護' },
-];
-
-const APPLICATION_STATUS_OPTIONS = [
-  { value: 'acquired', label: '取得済み' },
-  { value: 'applying', label: '申請中' },
-  { value: 'planning', label: '申請予定' },
-  { value: 'not_applicable', label: '該当なし' },
-];
-
-const PHYSICAL_DISABILITY_TYPE_OPTIONS = [
-  { value: 'visual', label: '視覚障害' },
-  { value: 'hearing', label: '聴覚障害' },
-  { value: 'limb', label: '肢体不自由' },
-  { value: 'internal', label: '内部障害' },
-  { value: 'other', label: 'その他' },
-];
-
-const RELATIONSHIP_OPTIONS = [
-  '父', '母', '配偶者', '子', '兄弟姉妹', '相談支援専門員', 'ケースワーカー', '医療機関', '友人・知人', 'その他'
-];
-
-// 等級・レベル選択肢
-const GRADE_LEVEL_OPTIONS = {
-  physical_handbook: [
-    { value: '1', label: '1級' },
-    { value: '2', label: '2級' },
-    { value: '3', label: '3級' },
-    { value: '4', label: '4級' },
-    { value: '5', label: '5級' },
-    { value: '6', label: '6級' },
-  ],
-  intellectual_handbook: [
-    { value: 'A', label: 'A（重度）' },
-    { value: 'B1', label: 'B1（中度）' },
-    { value: 'B2', label: 'B2（軽度）' },
-    { value: 'C', label: 'C（境界域）' },
-  ],
-  mental_health_handbook: [
-    { value: '1', label: '1級' },
-    { value: '2', label: '2級' },
-    { value: '3', label: '3級' },
-  ],
-  disability_basic_pension: [
-    { value: '1', label: '1級' },
-    { value: '2', label: '2級' },
-  ],
-  other_disability_pension: [
-    { value: '1', label: '1級' },
-    { value: '2', label: '2級' },
-    { value: '3', label: '3級' },
-  ],
-  public_assistance: [
-    { value: '介護扶助', label: '介護扶助' },
-    { value: '医療扶助', label: '医療扶助' },
-    { value: '生活扶助', label: '生活扶助' },
-    { value: 'その他', label: 'その他' },
-  ],
-};
+import BasicInfoSection from './forms/BasicInfoSection';
+import ContactSection from './forms/ContactSection';
+import DisabilityDetailsSection from './forms/DisabilityDetailsSection';
+import DisabilitySection from './forms/DisabilitySection';
+import EmergencyContactsSection from './forms/EmergencyContactsSection';
+import { RECIPIENT_FORM_SECTIONS } from './forms/recipientFormDefaults';
+import { mapWelfareRecipientToFormData } from './forms/recipientFormMapper';
+import type { RecipientFormData } from './forms/recipientFormTypes';
+import { useRecipientFormState } from './forms/useRecipientFormState';
+import { validateRecipientFormSection } from './forms/recipientFormValidation';
 
 const SENIOR_RECIPIENT_FORM_CLASS =
   'space-y-8 [&_h1]:text-4xl [&_h1]:font-bold [&_h2]:text-2xl [&_h2]:font-bold [&_h3]:text-2xl [&_h3]:font-bold [&_h4]:text-xl [&_h4]:font-bold [&_p]:text-base [&_p]:font-semibold [&_label]:text-lg [&_label]:font-bold [&_input]:text-lg [&_input]:font-semibold [&_input]:px-4 [&_input]:py-3 [&_select]:text-lg [&_select]:font-semibold [&_select]:px-4 [&_select]:py-3 [&_textarea]:text-lg [&_textarea]:font-semibold [&_textarea]:px-4 [&_textarea]:py-3 [&_button]:text-lg [&_button]:font-bold';
@@ -178,96 +29,36 @@ interface RecipientEditFormProps {
 export default function RecipientEditForm({ recipientId, initialData, onCancel }: RecipientEditFormProps) {
   const router = useRouter();
   const [currentSection, setCurrentSection] = useState(0);
-  const [formData, setFormData] = useState<FormData | null>(null);
+  const {
+    formData,
+    setFormData,
+    addEmergencyContact,
+    removeEmergencyContact,
+    addDisabilityDetail,
+    removeDisabilityDetail,
+    handleBasicInfoChange,
+    handleContactAddressChange,
+    handleEmergencyContactChange,
+    handleDisabilityInfoChange,
+    handleDisabilityDetailChange,
+  } = useRecipientFormState<RecipientFormData | null>(null);
   const [isLoading, setIsLoading] = useState(false);
   const [errors, setErrors] = useState<Record<string, string>>({});
 
   // Employee Action Request Modal state
   const [isRequestModalOpen, setIsRequestModalOpen] = useState(false);
-  const [pendingFormData, setPendingFormData] = useState<FormData | null>(null);
+  const [pendingFormData, setPendingFormData] = useState<RecipientFormData | null>(null);
 
   const { isEmployee } = useStaffRole();
 
-  const sections = [
-    { id: 0, title: '基本情報', description: '氏名・ふりがな・生年月日・性別' },
-    { id: 1, title: '連絡先・住所情報', description: '住所・居住形態・交通手段・電話番号' },
-    { id: 2, title: '緊急連絡先', description: '緊急時の連絡先情報' },
-    { id: 3, title: '障害・疾患情報', description: '障害または疾患名・生活保護受給状況' },
-    { id: 4, title: '手帳・年金詳細', description: '各種手帳・年金の詳細情報' },
-  ];
+  const sections = RECIPIENT_FORM_SECTIONS;
 
   // Initialize form data with existing recipient data
   useEffect(() => {
     if (initialData) {
-
-      const transformedData: FormData = {
-        basicInfo: {
-          firstName: initialData.first_name || '',
-          lastName: initialData.last_name || '',
-          firstNameFurigana: initialData.first_name_furigana || '',
-          lastNameFurigana: initialData.last_name_furigana || '',
-          birthDay: initialData.birth_day || '',
-          gender: initialData.gender || '',
-        },
-        contactAddress: {
-          address: initialData.detail?.address || '',
-          formOfResidence: initialData.detail?.formOfResidence || initialData.detail?.form_of_residence || '',
-          formOfResidenceOtherText: initialData.detail?.formOfResidenceOtherText || initialData.detail?.form_of_residence_other_text || '',
-          meansOfTransportation: initialData.detail?.meansOfTransportation || initialData.detail?.means_of_transportation || '',
-          meansOfTransportationOtherText: initialData.detail?.meansOfTransportationOtherText || initialData.detail?.means_of_transportation_other_text || '',
-          tel: initialData.detail?.tel || '',
-        },
-        emergencyContacts: (initialData.detail?.emergency_contacts?.length
-          ? initialData.detail.emergency_contacts.map(contact => ({
-              firstName: contact.firstName || contact.first_name || '',
-              lastName: contact.lastName || contact.last_name || '',
-              firstNameFurigana: contact.firstNameFurigana || contact.first_name_furigana || '',
-              lastNameFurigana: contact.lastNameFurigana || contact.last_name_furigana || '',
-              relationship: contact.relationship || '',
-              tel: contact.tel || '',
-              address: contact.address || '',
-              notes: contact.notes || '',
-              priority: contact.priority || 1,
-            }))
-          : [{
-              firstName: '',
-              lastName: '',
-              firstNameFurigana: '',
-              lastNameFurigana: '',
-              relationship: '',
-              tel: '',
-              address: '',
-              notes: '',
-              priority: 1,
-            }]
-        ),
-        disabilityInfo: {
-          disabilityOrDiseaseName: initialData.disability_status?.disabilityOrDiseaseName || initialData.disability_status?.disability_or_disease_name || '',
-          livelihoodProtection: initialData.disability_status?.livelihoodProtection || initialData.disability_status?.livelihood_protection || '',
-          specialRemarks: initialData.disability_status?.specialRemarks || initialData.disability_status?.special_remarks || '',
-        },
-        disabilityDetails: (initialData.disability_status?.details?.length
-          ? initialData.disability_status.details.map(detail => ({
-              category: detail.category || '',
-              gradeOrLevel: detail.gradeOrLevel || detail.grade_or_level || '',
-              physicalDisabilityType: detail.physicalDisabilityType || detail.physical_disability_type || '',
-              physicalDisabilityTypeOtherText: detail.physicalDisabilityTypeOtherText || detail.physical_disability_type_other_text || '',
-              applicationStatus: detail.applicationStatus || detail.application_status || '',
-            }))
-          : [{
-              category: '',
-              gradeOrLevel: '',
-              physicalDisabilityType: '',
-              physicalDisabilityTypeOtherText: '',
-              applicationStatus: '',
-            }]
-        ),
-      };
-
-
-      setFormData(transformedData);
+      setFormData(mapWelfareRecipientToFormData(initialData));
     }
-  }, [initialData]);
+  }, [initialData, setFormData]);
 
   // Progress calculation
   const getProgressPercentage = () => {
@@ -277,39 +68,7 @@ export default function RecipientEditForm({ recipientId, initialData, onCancel }
   // Form validation for each section
   const validateSection = (sectionId: number): boolean => {
     if (!formData) return false;
-    const newErrors: Record<string, string> = {};
-
-    switch (sectionId) {
-      case 0: // Basic Information
-        if (!formData.basicInfo.firstName) newErrors.firstName = '名は必須です';
-        if (!formData.basicInfo.lastName) newErrors.lastName = '姓は必須です';
-        if (!formData.basicInfo.firstNameFurigana) newErrors.firstNameFurigana = '名（ふりがな）は必須です';
-        if (!formData.basicInfo.lastNameFurigana) newErrors.lastNameFurigana = '姓（ふりがな）は必須です';
-        if (!formData.basicInfo.birthDay) newErrors.birthDay = '生年月日は必須です';
-        if (!formData.basicInfo.gender) newErrors.gender = '性別は必須です';
-        break;
-      case 1: // Contact & Address
-        if (!formData.contactAddress.address) newErrors.address = '住所は必須です';
-        if (!formData.contactAddress.formOfResidence) newErrors.formOfResidence = '居住形態は必須です';
-        if (!formData.contactAddress.meansOfTransportation) newErrors.meansOfTransportation = '交通手段は必須です';
-        if (!formData.contactAddress.tel) newErrors.tel = '電話番号は必須です';
-        break;
-      case 2: // Emergency Contact
-        formData.emergencyContacts.forEach((contact, index) => {
-          if (!contact.firstName) newErrors[`emergencyContact${index}FirstName`] = '名は必須です';
-          if (!contact.lastName) newErrors[`emergencyContact${index}LastName`] = '姓は必須です';
-          if (!contact.tel) newErrors[`emergencyContact${index}Tel`] = '電話番号は必須です';
-        });
-        break;
-      case 3: // Disability Info
-        if (!formData.disabilityInfo.disabilityOrDiseaseName) newErrors.disabilityOrDiseaseName = '障害または疾患名は必須です';
-        if (!formData.disabilityInfo.livelihoodProtection) newErrors.livelihoodProtection = '生活保護受給状況は必須です';
-        break;
-      case 4: // Disability Details
-        // Optional validation for disability details
-        break;
-    }
-
+    const newErrors = validateRecipientFormSection(formData, sectionId, 'edit');
     setErrors(newErrors);
     return Object.keys(newErrors).length === 0;
   };
@@ -346,7 +105,7 @@ export default function RecipientEditForm({ recipientId, initialData, onCancel }
     await executeSubmit(formData);
   };
 
-  const executeSubmit = async (data: FormData) => {
+  const executeSubmit = async (data: RecipientFormData) => {
     setIsLoading(true);
     try {
       // Transform form data to backend format
@@ -358,7 +117,6 @@ export default function RecipientEditForm({ recipientId, initialData, onCancel }
       // Redirect to dashboard with success message
       router.push('/dashboard?message=' + encodeURIComponent('利用者情報を更新しました'));
     } catch (error) {
-      console.error('Form submission error:', error);
       if (error instanceof Error) {
         setErrors({ submit: error.message || '更新に失敗しました。もう一度お試しください。' });
       } else {
@@ -372,117 +130,6 @@ export default function RecipientEditForm({ recipientId, initialData, onCancel }
   const handleRequestSuccess = () => {
     // リクエスト送信成功時の処理
     router.push('/dashboard?message=' + encodeURIComponent('利用者情報更新リクエストを送信しました。Manager/Ownerの承認をお待ちください。'));
-  };
-
-  // Add emergency contact
-  const addEmergencyContact = () => {
-    if (!formData) return;
-    if (formData.emergencyContacts.length < 3) {
-      setFormData(prev => prev ? ({
-        ...prev,
-        emergencyContacts: [...prev.emergencyContacts, {
-          firstName: '',
-          lastName: '',
-          firstNameFurigana: '',
-          lastNameFurigana: '',
-          relationship: '',
-          tel: '',
-          address: '',
-          notes: '',
-          priority: prev.emergencyContacts.length + 1,
-        }],
-      }) : null);
-    }
-  };
-
-  // Remove emergency contact
-  const removeEmergencyContact = (index: number) => {
-    if (!formData) return;
-    if (formData.emergencyContacts.length > 1) {
-      setFormData(prev => prev ? ({
-        ...prev,
-        emergencyContacts: prev.emergencyContacts.filter((_, i) => i !== index),
-      }) : null);
-    }
-  };
-
-  // Add disability detail
-  const addDisabilityDetail = () => {
-    if (!formData) return;
-    setFormData(prev => prev ? ({
-      ...prev,
-      disabilityDetails: [...prev.disabilityDetails, {
-        category: '',
-        gradeOrLevel: '',
-        physicalDisabilityType: '',
-        physicalDisabilityTypeOtherText: '',
-        applicationStatus: '',
-      }],
-    }) : null);
-  };
-
-  // Remove disability detail
-  const removeDisabilityDetail = (index: number) => {
-    if (!formData) return;
-    if (formData.disabilityDetails.length > 1) {
-      setFormData(prev => prev ? ({
-        ...prev,
-        disabilityDetails: prev.disabilityDetails.filter((_, i) => i !== index),
-      }) : null);
-    }
-  };
-
-  // Input handlers
-  const handleBasicInfoChange = (field: keyof BasicInfoData, value: string) => {
-    if (!formData) return;
-    setFormData(prev => prev ? ({
-      ...prev,
-      basicInfo: { ...prev.basicInfo, [field]: value },
-    }) : null);
-  };
-
-  const handleContactAddressChange = (field: keyof ContactAddressData, value: string) => {
-    if (!formData) return;
-    setFormData(prev => prev ? ({
-      ...prev,
-      contactAddress: { ...prev.contactAddress, [field]: value },
-    }) : null);
-  };
-
-  const handleEmergencyContactChange = (index: number, field: keyof EmergencyContactData, value: string) => {
-    if (!formData) return;
-    setFormData(prev => prev ? ({
-      ...prev,
-      emergencyContacts: prev.emergencyContacts.map((contact, i) =>
-        i === index ? { ...contact, [field]: value } : contact
-      ),
-    }) : null);
-  };
-
-  const handleDisabilityInfoChange = (field: keyof DisabilityInfoData, value: string) => {
-    if (!formData) return;
-    setFormData(prev => prev ? ({
-      ...prev,
-      disabilityInfo: { ...prev.disabilityInfo, [field]: value },
-    }) : null);
-  };
-
-  const handleDisabilityDetailChange = (index: number, field: keyof DisabilityDetailData, value: string) => {
-    if (!formData) return;
-    setFormData(prev => prev ? ({
-      ...prev,
-      disabilityDetails: prev.disabilityDetails.map((detail, i) => {
-        if (i === index) {
-          const updatedDetail = { ...detail, [field]: value };
-          // カテゴリが変更された場合、等級・レベルをリセット
-          if (field === 'category') {
-            updatedDetail.gradeOrLevel = '';
-          }
-          return updatedDetail;
-        }
-        return detail;
-      }),
-    }) : null);
   };
 
   if (!formData) {
@@ -533,520 +180,49 @@ export default function RecipientEditForm({ recipientId, initialData, onCancel }
 
       {/* Form Content */}
       <div className="bg-white dark:bg-[#0f1419cc] rounded-lg border border-slate-300 dark:border-[#2a3441] p-8">
-        {/* Basic Information Section */}
         {currentSection === 0 && (
-          <div className="space-y-6">
-            <h3 className="text-lg font-semibold text-slate-950 dark:text-white mb-4">基本情報</h3>
-
-            <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
-              <div>
-                <label className="block text-sm font-medium text-slate-700 dark:text-gray-300 mb-2">
-                  姓 <span className="text-red-400">*</span>
-                </label>
-                <input
-                  type="text"
-                  value={formData.basicInfo.lastName}
-                  onChange={(e) => handleBasicInfoChange('lastName', e.target.value)}
-                  className={`w-full px-3 py-2 bg-white dark:bg-[#1a1f2e] border rounded-lg text-slate-900 dark:text-white placeholder-slate-500 dark:placeholder-gray-500 focus:outline-none focus:ring-2 focus:ring-[#10b981] ${
-                    errors.lastName ? 'border-red-500' : 'border-slate-300 dark:border-[#2a3441]'
-                  }`}
-                  placeholder="山田"
-                />
-                {errors.lastName && <p className="text-red-400 text-sm mt-1">{errors.lastName}</p>}
-              </div>
-
-              <div>
-                <label className="block text-sm font-medium text-slate-700 dark:text-gray-300 mb-2">
-                  名 <span className="text-red-400">*</span>
-                </label>
-                <input
-                  type="text"
-                  value={formData.basicInfo.firstName}
-                  onChange={(e) => handleBasicInfoChange('firstName', e.target.value)}
-                  className={`w-full px-3 py-2 bg-white dark:bg-[#1a1f2e] border rounded-lg text-slate-900 dark:text-white placeholder-slate-500 dark:placeholder-gray-500 focus:outline-none focus:ring-2 focus:ring-[#10b981] ${
-                    errors.firstName ? 'border-red-500' : 'border-slate-300 dark:border-[#2a3441]'
-                  }`}
-                  placeholder="太郎"
-                />
-                {errors.firstName && <p className="text-red-400 text-sm mt-1">{errors.firstName}</p>}
-              </div>
-
-              <div>
-                <label className="block text-sm font-medium text-slate-700 dark:text-gray-300 mb-2">
-                  姓（ふりがな） <span className="text-red-400">*</span>
-                </label>
-                <input
-                  type="text"
-                  value={formData.basicInfo.lastNameFurigana}
-                  onChange={(e) => handleBasicInfoChange('lastNameFurigana', e.target.value)}
-                  className={`w-full px-3 py-2 bg-white dark:bg-[#1a1f2e] border rounded-lg text-slate-900 dark:text-white placeholder-slate-500 dark:placeholder-gray-500 focus:outline-none focus:ring-2 focus:ring-[#10b981] ${
-                    errors.lastNameFurigana ? 'border-red-500' : 'border-slate-300 dark:border-[#2a3441]'
-                  }`}
-                  placeholder="やまだ"
-                />
-                {errors.lastNameFurigana && <p className="text-red-400 text-sm mt-1">{errors.lastNameFurigana}</p>}
-              </div>
-
-              <div>
-                <label className="block text-sm font-medium text-slate-700 dark:text-gray-300 mb-2">
-                  名（ふりがな） <span className="text-red-400">*</span>
-                </label>
-                <input
-                  type="text"
-                  value={formData.basicInfo.firstNameFurigana}
-                  onChange={(e) => handleBasicInfoChange('firstNameFurigana', e.target.value)}
-                  className={`w-full px-3 py-2 bg-white dark:bg-[#1a1f2e] border rounded-lg text-slate-900 dark:text-white placeholder-slate-500 dark:placeholder-gray-500 focus:outline-none focus:ring-2 focus:ring-[#10b981] ${
-                    errors.firstNameFurigana ? 'border-red-500' : 'border-slate-300 dark:border-[#2a3441]'
-                  }`}
-                  placeholder="たろう"
-                />
-                {errors.firstNameFurigana && <p className="text-red-400 text-sm mt-1">{errors.firstNameFurigana}</p>}
-              </div>
-
-              <div>
-                <label className="block text-sm font-medium text-slate-700 dark:text-gray-300 mb-2">
-                  生年月日 <span className="text-red-400">*</span>
-                </label>
-                <DateDrumPicker
-                  value={formData.basicInfo.birthDay}
-                  onChange={(date) => handleBasicInfoChange('birthDay', date)}
-                  error={!!errors.birthDay}
-                  minYear={1900}
-                  maxYear={new Date().getFullYear()}
-                />
-                {errors.birthDay && <p className="text-red-400 text-sm mt-1">{errors.birthDay}</p>}
-              </div>
-
-              <div>
-                <label className="block text-sm font-medium text-slate-700 dark:text-gray-300 mb-2">
-                  性別 <span className="text-red-400">*</span>
-                </label>
-                <select
-                  value={formData.basicInfo.gender}
-                  onChange={(e) => handleBasicInfoChange('gender', e.target.value)}
-                  className={`w-full px-3 py-2 bg-white dark:bg-[#1a1f2e] border rounded-lg text-slate-900 dark:text-white focus:outline-none focus:ring-2 focus:ring-[#10b981] ${
-                    errors.gender ? 'border-red-500' : 'border-slate-300 dark:border-[#2a3441]'
-                  }`}
-                >
-                  <option value="">選択してください</option>
-                  {GENDER_OPTIONS.map(option => (
-                    <option key={option.value} value={option.value}>{option.label}</option>
-                  ))}
-                </select>
-                {errors.gender && <p className="text-red-400 text-sm mt-1">{errors.gender}</p>}
-              </div>
-            </div>
-          </div>
+          <BasicInfoSection
+            formData={formData}
+            errors={errors}
+            handleBasicInfoChange={handleBasicInfoChange}
+          />
         )}
 
-        {/* Contact & Address Section */}
         {currentSection === 1 && (
-          <div className="space-y-6">
-            <h3 className="text-lg font-semibold text-slate-950 dark:text-white mb-4">連絡先・住所情報</h3>
-
-            <div>
-              <label className="block text-sm font-medium text-slate-700 dark:text-gray-300 mb-2">
-                住所 <span className="text-red-400">*</span>
-              </label>
-              <textarea
-                value={formData.contactAddress.address}
-                onChange={(e) => handleContactAddressChange('address', e.target.value)}
-                rows={3}
-                className={`w-full px-3 py-2 bg-white dark:bg-[#1a1f2e] border rounded-lg text-slate-900 dark:text-white placeholder-slate-500 dark:placeholder-gray-500 focus:outline-none focus:ring-2 focus:ring-[#10b981] ${
-                  errors.address ? 'border-red-500' : 'border-slate-300 dark:border-[#2a3441]'
-                }`}
-                placeholder="例：東京都新宿区西新宿1-1-1"
-              />
-              {errors.address && <p className="text-red-400 text-sm mt-1">{errors.address}</p>}
-            </div>
-
-            <div>
-              <label className="block text-sm font-medium text-slate-700 dark:text-gray-300 mb-2">
-                居住形態 <span className="text-red-400">*</span>
-              </label>
-              <select
-                value={formData.contactAddress.formOfResidence}
-                onChange={(e) => handleContactAddressChange('formOfResidence', e.target.value)}
-                className={`w-full px-3 py-2 bg-white dark:bg-[#1a1f2e] border rounded-lg text-slate-900 dark:text-white focus:outline-none focus:ring-2 focus:ring-[#10b981] ${
-                  errors.formOfResidence ? 'border-red-500' : 'border-slate-300 dark:border-[#2a3441]'
-                }`}
-              >
-                <option value="">選択してください</option>
-                {FORM_OF_RESIDENCE_OPTIONS.map(option => (
-                  <option key={option.value} value={option.value}>{option.label}</option>
-                ))}
-              </select>
-              {errors.formOfResidence && <p className="text-red-400 text-sm mt-1">{errors.formOfResidence}</p>}
-            </div>
-
-            {formData.contactAddress.formOfResidence === 'other' && (
-              <div>
-                <label className="block text-sm font-medium text-slate-700 dark:text-gray-300 mb-2">その他詳細</label>
-                <input
-                  type="text"
-                  value={formData.contactAddress.formOfResidenceOtherText || ''}
-                  onChange={(e) => handleContactAddressChange('formOfResidenceOtherText', e.target.value)}
-                  className="w-full px-3 py-2 bg-white dark:bg-[#1a1f2e] border border-slate-300 dark:border-[#2a3441] rounded-lg text-slate-900 dark:text-white placeholder-slate-500 dark:placeholder-gray-500 focus:outline-none focus:ring-2 focus:ring-[#10b981]"
-                  placeholder="詳細を入力してください"
-                />
-              </div>
-            )}
-
-            <div>
-              <label className="block text-sm font-medium text-slate-700 dark:text-gray-300 mb-2">
-                交通手段 <span className="text-red-400">*</span>
-              </label>
-              <select
-                value={formData.contactAddress.meansOfTransportation}
-                onChange={(e) => handleContactAddressChange('meansOfTransportation', e.target.value)}
-                className={`w-full px-3 py-2 bg-white dark:bg-[#1a1f2e] border rounded-lg text-slate-900 dark:text-white focus:outline-none focus:ring-2 focus:ring-[#10b981] ${
-                  errors.meansOfTransportation ? 'border-red-500' : 'border-slate-300 dark:border-[#2a3441]'
-                }`}
-              >
-                <option value="">選択してください</option>
-                {MEANS_OF_TRANSPORTATION_OPTIONS.map(option => (
-                  <option key={option.value} value={option.value}>{option.label}</option>
-                ))}
-              </select>
-              {errors.meansOfTransportation && <p className="text-red-400 text-sm mt-1">{errors.meansOfTransportation}</p>}
-            </div>
-
-            {formData.contactAddress.meansOfTransportation === 'other' && (
-              <div>
-                <label className="block text-sm font-medium text-slate-700 dark:text-gray-300 mb-2">その他詳細</label>
-                <input
-                  type="text"
-                  value={formData.contactAddress.meansOfTransportationOtherText || ''}
-                  onChange={(e) => handleContactAddressChange('meansOfTransportationOtherText', e.target.value)}
-                  className="w-full px-3 py-2 bg-white dark:bg-[#1a1f2e] border border-slate-300 dark:border-[#2a3441] rounded-lg text-slate-900 dark:text-white placeholder-slate-500 dark:placeholder-gray-500 focus:outline-none focus:ring-2 focus:ring-[#10b981]"
-                  placeholder="詳細を入力してください"
-                />
-              </div>
-            )}
-
-            <div>
-              <label className="block text-sm font-medium text-slate-700 dark:text-gray-300 mb-2">
-                電話番号 <span className="text-red-400">*</span>
-              </label>
-              <input
-                type="tel"
-                value={formData.contactAddress.tel}
-                onChange={(e) => handleContactAddressChange('tel', e.target.value)}
-                className={`w-full px-3 py-2 bg-white dark:bg-[#1a1f2e] border rounded-lg text-slate-900 dark:text-white placeholder-slate-500 dark:placeholder-gray-500 focus:outline-none focus:ring-2 focus:ring-[#10b981] ${
-                  errors.tel ? 'border-red-500' : 'border-slate-300 dark:border-[#2a3441]'
-                }`}
-                placeholder="例：090-1234-5678"
-              />
-              {errors.tel && <p className="text-red-400 text-sm mt-1">{errors.tel}</p>}
-            </div>
-          </div>
+          <ContactSection
+            formData={formData}
+            errors={errors}
+            handleContactAddressChange={handleContactAddressChange}
+          />
         )}
 
-        {/* Emergency Contacts Section */}
         {currentSection === 2 && (
-          <div className="space-y-6">
-            <div className="flex items-center justify-between mb-4">
-              <h3 className="text-lg font-semibold text-slate-950 dark:text-white">緊急連絡先情報</h3>
-              <button
-                onClick={addEmergencyContact}
-                disabled={formData.emergencyContacts.length >= 3}
-                className="bg-[#10b981] hover:bg-[#0f9f6e] disabled:bg-gray-600 disabled:cursor-not-allowed text-white px-4 py-2 rounded-lg text-sm font-medium transition-colors"
-              >
-                + 連絡先を追加
-              </button>
-            </div>
-
-            {formData.emergencyContacts.map((contact, index) => (
-              <div key={index} className="border border-slate-300 dark:border-[#2a3441] rounded-lg p-6 relative">
-                {formData.emergencyContacts.length > 1 && (
-                  <button
-                    onClick={() => removeEmergencyContact(index)}
-                    className="absolute top-4 right-4 px-3 py-1 bg-red-600/20 hover:bg-red-600/30 text-red-400 hover:text-red-300 rounded text-sm transition-colors"
-                  >
-                    削除
-                  </button>
-                )}
-
-                <h4 className="text-md font-medium text-slate-900 dark:text-white mb-4">緊急連絡先 {index + 1}</h4>
-
-                <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
-                  <div>
-                    <label className="block text-sm font-medium text-slate-700 dark:text-gray-300 mb-2">
-                      姓 <span className="text-red-400">*</span>
-                    </label>
-                    <input
-                      type="text"
-                      value={contact.lastName}
-                      onChange={(e) => handleEmergencyContactChange(index, 'lastName', e.target.value)}
-                      className={`w-full px-3 py-2 bg-white dark:bg-[#1a1f2e] border rounded-lg text-slate-900 dark:text-white placeholder-slate-500 dark:placeholder-gray-500 focus:outline-none focus:ring-2 focus:ring-[#10b981] ${
-                        errors[`emergencyContact${index}LastName`] ? 'border-red-500' : 'border-slate-300 dark:border-[#2a3441]'
-                      }`}
-                      placeholder="田中"
-                    />
-                    {errors[`emergencyContact${index}LastName`] && (
-                      <p className="text-red-400 text-sm mt-1">{errors[`emergencyContact${index}LastName`]}</p>
-                    )}
-                  </div>
-
-                  <div>
-                    <label className="block text-sm font-medium text-slate-700 dark:text-gray-300 mb-2">
-                      名 <span className="text-red-400">*</span>
-                    </label>
-                    <input
-                      type="text"
-                      value={contact.firstName}
-                      onChange={(e) => handleEmergencyContactChange(index, 'firstName', e.target.value)}
-                      className={`w-full px-3 py-2 bg-white dark:bg-[#1a1f2e] border rounded-lg text-slate-900 dark:text-white placeholder-slate-500 dark:placeholder-gray-500 focus:outline-none focus:ring-2 focus:ring-[#10b981] ${
-                        errors[`emergencyContact${index}FirstName`] ? 'border-red-500' : 'border-slate-300 dark:border-[#2a3441]'
-                      }`}
-                      placeholder="花子"
-                    />
-                    {errors[`emergencyContact${index}FirstName`] && (
-                      <p className="text-red-400 text-sm mt-1">{errors[`emergencyContact${index}FirstName`]}</p>
-                    )}
-                  </div>
-
-                  <div>
-                    <label className="block text-sm font-medium text-slate-700 dark:text-gray-300 mb-2">姓（ふりがな）</label>
-                    <input
-                      type="text"
-                      value={contact.lastNameFurigana}
-                      onChange={(e) => handleEmergencyContactChange(index, 'lastNameFurigana', e.target.value)}
-                      className="w-full px-3 py-2 bg-white dark:bg-[#1a1f2e] border border-slate-300 dark:border-[#2a3441] rounded-lg text-slate-900 dark:text-white placeholder-slate-500 dark:placeholder-gray-500 focus:outline-none focus:ring-2 focus:ring-[#10b981]"
-                      placeholder="たなか"
-                    />
-                  </div>
-
-                  <div>
-                    <label className="block text-sm font-medium text-slate-700 dark:text-gray-300 mb-2">名（ふりがな）</label>
-                    <input
-                      type="text"
-                      value={contact.firstNameFurigana}
-                      onChange={(e) => handleEmergencyContactChange(index, 'firstNameFurigana', e.target.value)}
-                      className="w-full px-3 py-2 bg-white dark:bg-[#1a1f2e] border border-slate-300 dark:border-[#2a3441] rounded-lg text-slate-900 dark:text-white placeholder-slate-500 dark:placeholder-gray-500 focus:outline-none focus:ring-2 focus:ring-[#10b981]"
-                      placeholder="はなこ"
-                    />
-                  </div>
-
-                  <div>
-                    <label className="block text-sm font-medium text-slate-700 dark:text-gray-300 mb-2">続柄・関係性</label>
-                    <select
-                      value={contact.relationship}
-                      onChange={(e) => handleEmergencyContactChange(index, 'relationship', e.target.value)}
-                      className="w-full px-3 py-2 bg-white dark:bg-[#1a1f2e] border border-slate-300 dark:border-[#2a3441] rounded-lg text-slate-900 dark:text-white focus:outline-none focus:ring-2 focus:ring-[#10b981]"
-                    >
-                      <option value="">選択してください</option>
-                      {RELATIONSHIP_OPTIONS.map(option => (
-                        <option key={option} value={option}>{option}</option>
-                      ))}
-                    </select>
-                  </div>
-
-                  <div>
-                    <label className="block text-sm font-medium text-slate-700 dark:text-gray-300 mb-2">
-                      電話番号 <span className="text-red-400">*</span>
-                    </label>
-                    <input
-                      type="tel"
-                      value={contact.tel}
-                      onChange={(e) => handleEmergencyContactChange(index, 'tel', e.target.value)}
-                      className={`w-full px-3 py-2 bg-white dark:bg-[#1a1f2e] border rounded-lg text-slate-900 dark:text-white placeholder-slate-500 dark:placeholder-gray-500 focus:outline-none focus:ring-2 focus:ring-[#10b981] ${
-                        errors[`emergencyContact${index}Tel`] ? 'border-red-500' : 'border-slate-300 dark:border-[#2a3441]'
-                      }`}
-                      placeholder="例：090-1234-5678"
-                    />
-                    {errors[`emergencyContact${index}Tel`] && (
-                      <p className="text-red-400 text-sm mt-1">{errors[`emergencyContact${index}Tel`]}</p>
-                    )}
-                  </div>
-                </div>
-
-                <div className="mt-4">
-                  <label className="block text-sm font-medium text-slate-700 dark:text-gray-300 mb-2">住所</label>
-                  <input
-                    type="text"
-                    value={contact.address || ''}
-                    onChange={(e) => handleEmergencyContactChange(index, 'address', e.target.value)}
-                    className="w-full px-3 py-2 bg-white dark:bg-[#1a1f2e] border border-slate-300 dark:border-[#2a3441] rounded-lg text-slate-900 dark:text-white placeholder-slate-500 dark:placeholder-gray-500 focus:outline-none focus:ring-2 focus:ring-[#10b981]"
-                    placeholder="住所（任意）"
-                  />
-                </div>
-
-                <div className="mt-4">
-                  <label className="block text-sm font-medium text-slate-700 dark:text-gray-300 mb-2">備考</label>
-                  <textarea
-                    value={contact.notes || ''}
-                    onChange={(e) => handleEmergencyContactChange(index, 'notes', e.target.value)}
-                    rows={2}
-                    className="w-full px-3 py-2 bg-white dark:bg-[#1a1f2e] border border-slate-300 dark:border-[#2a3441] rounded-lg text-slate-900 dark:text-white placeholder-slate-500 dark:placeholder-gray-500 focus:outline-none focus:ring-2 focus:ring-[#10b981]"
-                    placeholder="備考（任意）"
-                  />
-                </div>
-              </div>
-            ))}
-          </div>
+          <EmergencyContactsSection
+            mode="edit"
+            formData={formData}
+            errors={errors}
+            addEmergencyContact={addEmergencyContact}
+            removeEmergencyContact={removeEmergencyContact}
+            handleEmergencyContactChange={handleEmergencyContactChange}
+          />
         )}
 
-        {/* Disability Information Section */}
         {currentSection === 3 && (
-          <div className="space-y-6">
-            <h3 className="text-lg font-semibold text-slate-950 dark:text-white mb-4">障害・疾患情報</h3>
-
-            <div>
-              <label className="block text-sm font-medium text-slate-700 dark:text-gray-300 mb-2">
-                障害または疾患名 <span className="text-red-400">*</span>
-              </label>
-              <textarea
-                value={formData.disabilityInfo.disabilityOrDiseaseName}
-                onChange={(e) => handleDisabilityInfoChange('disabilityOrDiseaseName', e.target.value)}
-                rows={3}
-                className={`w-full px-3 py-2 bg-white dark:bg-[#1a1f2e] border rounded-lg text-slate-900 dark:text-white placeholder-slate-500 dark:placeholder-gray-500 focus:outline-none focus:ring-2 focus:ring-[#10b981] ${
-                  errors.disabilityOrDiseaseName ? 'border-red-500' : 'border-slate-300 dark:border-[#2a3441]'
-                }`}
-                placeholder="例：統合失調症、知的障害、身体障害など"
-              />
-              {errors.disabilityOrDiseaseName && <p className="text-red-400 text-sm mt-1">{errors.disabilityOrDiseaseName}</p>}
-            </div>
-
-            <div>
-              <label className="block text-sm font-medium text-slate-700 dark:text-gray-300 mb-2">
-                生活保護受給状況 <span className="text-red-400">*</span>
-              </label>
-              <select
-                value={formData.disabilityInfo.livelihoodProtection}
-                onChange={(e) => handleDisabilityInfoChange('livelihoodProtection', e.target.value)}
-                className={`w-full px-3 py-2 bg-white dark:bg-[#1a1f2e] border rounded-lg text-slate-900 dark:text-white focus:outline-none focus:ring-2 focus:ring-[#10b981] ${
-                  errors.livelihoodProtection ? 'border-red-500' : 'border-slate-300 dark:border-[#2a3441]'
-                }`}
-              >
-                <option value="">選択してください</option>
-                {LIVELIHOOD_PROTECTION_OPTIONS.map(option => (
-                  <option key={option.value} value={option.value}>{option.label}</option>
-                ))}
-              </select>
-              {errors.livelihoodProtection && <p className="text-red-400 text-sm mt-1">{errors.livelihoodProtection}</p>}
-            </div>
-
-            <div>
-              <label className="block text-sm font-medium text-slate-700 dark:text-gray-300 mb-2">特記事項</label>
-              <textarea
-                value={formData.disabilityInfo.specialRemarks || ''}
-                onChange={(e) => handleDisabilityInfoChange('specialRemarks', e.target.value)}
-                rows={4}
-                maxLength={2000}
-                className="w-full px-3 py-2 bg-white dark:bg-[#1a1f2e] border border-slate-300 dark:border-[#2a3441] rounded-lg text-slate-900 dark:text-white placeholder-slate-500 dark:placeholder-gray-500 focus:outline-none focus:ring-2 focus:ring-[#10b981]"
-                placeholder="手帳情報以外の重要な障害特性、配慮事項、医療的ケアの必要性等（2000文字以内）"
-              />
-              <div className="text-right text-xs text-slate-600 dark:text-gray-400 mt-1">
-                {(formData.disabilityInfo.specialRemarks || '').length}/2000文字
-              </div>
-            </div>
-          </div>
+          <DisabilitySection
+            formData={formData}
+            errors={errors}
+            handleDisabilityInfoChange={handleDisabilityInfoChange}
+          />
         )}
 
-        {/* Disability Details Section */}
         {currentSection === 4 && (
-          <div className="space-y-6">
-            <div className="flex items-center justify-between mb-4">
-              <h3 className="text-lg font-semibold text-slate-950 dark:text-white">手帳・年金詳細情報</h3>
-              <button
-                onClick={addDisabilityDetail}
-                className="bg-[#10b981] hover:bg-[#0f9f6e] text-white px-4 py-2 rounded-lg text-sm font-medium transition-colors"
-              >
-                + 手帳・年金情報を追加
-              </button>
-            </div>
-
-            {formData.disabilityDetails.map((detail, index) => (
-              <div key={index} className="border border-slate-300 dark:border-[#2a3441] rounded-lg p-6 relative">
-                {formData.disabilityDetails.length > 1 && (
-                  <button
-                    onClick={() => removeDisabilityDetail(index)}
-                    className="absolute top-4 right-4 px-3 py-1 bg-red-600/20 hover:bg-red-600/30 text-red-400 hover:text-red-300 rounded text-sm transition-colors"
-                  >
-                    削除
-                  </button>
-                )}
-
-                <h4 className="text-md font-medium text-slate-900 dark:text-white mb-4">手帳・年金情報 {index + 1}</h4>
-
-                <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
-                  <div className="md:col-span-2">
-                    <label className="block text-sm font-medium text-slate-700 dark:text-gray-300 mb-2">カテゴリ</label>
-                    <select
-                      value={detail.category}
-                      onChange={(e) => handleDisabilityDetailChange(index, 'category', e.target.value)}
-                      className="w-full px-3 py-2 bg-white dark:bg-[#1a1f2e] border border-slate-300 dark:border-[#2a3441] rounded-lg text-slate-900 dark:text-white focus:outline-none focus:ring-2 focus:ring-[#10b981]"
-                    >
-                      <option value="">選択してください</option>
-                      {DISABILITY_CATEGORY_OPTIONS.map(option => (
-                        <option key={option.value} value={option.value}>{option.label}</option>
-                      ))}
-                    </select>
-                  </div>
-
-                  <div>
-                    <label className="block text-sm font-medium text-slate-700 dark:text-gray-300 mb-2">等級・レベル</label>
-                    <select
-                      value={detail.gradeOrLevel || ''}
-                      onChange={(e) => handleDisabilityDetailChange(index, 'gradeOrLevel', e.target.value)}
-                      className="w-full px-3 py-2 bg-white dark:bg-[#1a1f2e] border border-slate-300 dark:border-[#2a3441] rounded-lg text-slate-900 dark:text-white focus:outline-none focus:ring-2 focus:ring-[#10b981]"
-                    >
-                      <option value="">選択してください</option>
-                      {detail.category && GRADE_LEVEL_OPTIONS[detail.category as keyof typeof GRADE_LEVEL_OPTIONS]?.map(option => (
-                        <option key={option.value} value={option.value}>{option.label}</option>
-                      ))}
-                    </select>
-                  </div>
-
-                  <div>
-                    <label className="block text-sm font-medium text-slate-700 dark:text-gray-300 mb-2">申請状況</label>
-                    <select
-                      value={detail.applicationStatus}
-                      onChange={(e) => handleDisabilityDetailChange(index, 'applicationStatus', e.target.value)}
-                      className="w-full px-3 py-2 bg-white dark:bg-[#1a1f2e] border border-slate-300 dark:border-[#2a3441] rounded-lg text-slate-900 dark:text-white focus:outline-none focus:ring-2 focus:ring-[#10b981]"
-                    >
-                      <option value="">選択してください</option>
-                      {APPLICATION_STATUS_OPTIONS.map(option => (
-                        <option key={option.value} value={option.value}>{option.label}</option>
-                      ))}
-                    </select>
-                  </div>
-
-                  {detail.category === 'physical_handbook' && (
-                    <>
-                      <div>
-                        <label className="block text-sm font-medium text-slate-700 dark:text-gray-300 mb-2">身体障害種別</label>
-                        <select
-                          value={detail.physicalDisabilityType || ''}
-                          onChange={(e) => handleDisabilityDetailChange(index, 'physicalDisabilityType', e.target.value)}
-                          className="w-full px-3 py-2 bg-white dark:bg-[#1a1f2e] border border-slate-300 dark:border-[#2a3441] rounded-lg text-slate-900 dark:text-white focus:outline-none focus:ring-2 focus:ring-[#10b981]"
-                        >
-                          <option value="">選択してください</option>
-                          {PHYSICAL_DISABILITY_TYPE_OPTIONS.map(option => (
-                            <option key={option.value} value={option.value}>{option.label}</option>
-                          ))}
-                        </select>
-                      </div>
-
-                      {detail.physicalDisabilityType === 'other' && (
-                        <div>
-                          <label className="block text-sm font-medium text-slate-700 dark:text-gray-300 mb-2">その他詳細</label>
-                          <input
-                            type="text"
-                            value={detail.physicalDisabilityTypeOtherText || ''}
-                            onChange={(e) => handleDisabilityDetailChange(index, 'physicalDisabilityTypeOtherText', e.target.value)}
-                            className="w-full px-3 py-2 bg-white dark:bg-[#1a1f2e] border border-slate-300 dark:border-[#2a3441] rounded-lg text-slate-900 dark:text-white placeholder-slate-500 dark:placeholder-gray-500 focus:outline-none focus:ring-2 focus:ring-[#10b981]"
-                            placeholder="詳細を入力してください"
-                          />
-                        </div>
-                      )}
-                    </>
-                  )}
-                </div>
-              </div>
-            ))}
-          </div>
+          <DisabilityDetailsSection
+            mode="edit"
+            formData={formData}
+            addDisabilityDetail={addDisabilityDetail}
+            removeDisabilityDetail={removeDisabilityDetail}
+            handleDisabilityDetailChange={handleDisabilityDetailChange}
+          />
         )}
 
         {errors.submit && (

--- a/components/protected/recipients/RecipientRegistrationForm.tsx
+++ b/components/protected/recipients/RecipientRegistrationForm.tsx
@@ -2,10 +2,22 @@
 
 import { useEffect, useState } from 'react';
 import { useRouter } from 'next/navigation';
-import DateDrumPicker from '@/components/ui/DateDrumPicker';
 import EmployeeActionRequestModal from '@/components/common/EmployeeActionRequestModal';
 import { useStaffRole } from '@/hooks/useStaffRole';
 import { ActionType, ResourceType } from '@/types/employeeActionRequest';
+import BasicInfoSection from './forms/BasicInfoSection';
+import ContactSection from './forms/ContactSection';
+import DisabilityDetailsSection from './forms/DisabilityDetailsSection';
+import DisabilitySection from './forms/DisabilitySection';
+import EmergencyContactsSection from './forms/EmergencyContactsSection';
+import {
+  createEmptyDisabilityDetail,
+  INITIAL_RECIPIENT_FORM_DATA,
+  RECIPIENT_FORM_SECTIONS,
+} from './forms/recipientFormDefaults';
+import type { RecipientFormData } from './forms/recipientFormTypes';
+import { useRecipientFormState } from './forms/useRecipientFormState';
+import { validateRecipientFormSection } from './forms/recipientFormValidation';
 
 // エラーフィールドの日本語マッピング
 const ERROR_FIELD_MAPPING: Record<string, string> = {
@@ -45,235 +57,35 @@ function translateErrorMessage(error: string): string {
   return translatedError;
 }
 
-// Basic Information Section
-interface BasicInfoData {
-  firstName: string;
-  lastName: string;
-  firstNameFurigana: string;
-  lastNameFurigana: string;
-  birthDay: string;
-  gender: string;
-}
-
-// Contact & Address Information Section
-interface ContactAddressData {
-  address: string;
-  formOfResidence: string;
-  formOfResidenceOtherText?: string;
-  meansOfTransportation: string;
-  meansOfTransportationOtherText?: string;
-  tel: string;
-}
-
-// Emergency Contact Information
-interface EmergencyContactData {
-  firstName: string;
-  lastName: string;
-  firstNameFurigana: string;
-  lastNameFurigana: string;
-  relationship: string;
-  tel: string;
-  address?: string;
-  notes?: string;
-  priority: number;
-}
-
-// Disability & Disease Information Section
-interface DisabilityInfoData {
-  disabilityOrDiseaseName: string;
-  livelihoodProtection: string;
-  specialRemarks?: string;
-}
-
-// Disability Detail Information
-interface DisabilityDetailData {
-  category: string;
-  gradeOrLevel?: string;
-  physicalDisabilityType?: string;
-  physicalDisabilityTypeOtherText?: string;
-  applicationStatus: string;
-}
-
-interface FormData {
-  basicInfo: BasicInfoData;
-  contactAddress: ContactAddressData;
-  emergencyContacts: EmergencyContactData[];
-  disabilityInfo: DisabilityInfoData;
-  disabilityDetails: DisabilityDetailData[];
-}
-
-const createEmptyDisabilityDetail = (): DisabilityDetailData => ({
-  category: '',
-  gradeOrLevel: '',
-  physicalDisabilityType: '',
-  physicalDisabilityTypeOtherText: '',
-  applicationStatus: '',
-});
-
-const INITIAL_FORM_DATA: FormData = {
-  basicInfo: {
-    firstName: '',
-    lastName: '',
-    firstNameFurigana: '',
-    lastNameFurigana: '',
-    birthDay: '',
-    gender: '',
-  },
-  contactAddress: {
-    address: '',
-    formOfResidence: '',
-    formOfResidenceOtherText: '',
-    meansOfTransportation: '',
-    meansOfTransportationOtherText: '',
-    tel: '',
-  },
-  emergencyContacts: [
-    {
-      firstName: '',
-      lastName: '',
-      firstNameFurigana: '',
-      lastNameFurigana: '',
-      relationship: '',
-      tel: '',
-      address: '',
-      notes: '',
-      priority: 1,
-    },
-  ],
-  disabilityInfo: {
-    disabilityOrDiseaseName: '',
-    livelihoodProtection: '',
-    specialRemarks: '',
-  },
-  // 手帳・年金詳細は任意項目のため初期値は空配列とする
-  // （空エントリを持つとバックエンドの enum バリデーションで 422 エラーになる）
-  disabilityDetails: [],
-};
-
-// Enum options for dropdowns
-const GENDER_OPTIONS = [
-  { value: 'male', label: '男性' },
-  { value: 'female', label: '女性' },
-  { value: 'other', label: 'その他' },
-];
-
-const FORM_OF_RESIDENCE_OPTIONS = [
-  { value: 'home_with_family', label: '自宅（家族と同居）' },
-  { value: 'home_alone', label: '自宅（一人暮らし）' },
-  { value: 'group_home', label: 'グループホーム' },
-  { value: 'institution', label: '入所施設' },
-  { value: 'hospital', label: '病院・医療機関' },
-  { value: 'other', label: 'その他' },
-];
-
-const MEANS_OF_TRANSPORTATION_OPTIONS = [
-  { value: 'walk', label: '徒歩' },
-  { value: 'bicycle', label: '自転車' },
-  { value: 'motorbike', label: 'バイク・原付' },
-  { value: 'car_self', label: '自家用車（自分で運転）' },
-  { value: 'car_transport', label: '自家用車（送迎）' },
-  { value: 'public_transport', label: '公共交通機関（電車・バス）' },
-  { value: 'welfare_transport', label: '福祉輸送サービス' },
-  { value: 'other', label: 'その他' },
-];
-
-const LIVELIHOOD_PROTECTION_OPTIONS = [
-  { value: 'not_receiving', label: 'なし' },
-  { value: 'receiving_with_allowance', label: 'あり（他人介護料有り）' },
-  { value: 'receiving_without_allowance', label: 'あり（他人介護料無し）' },
-  { value: 'applying', label: '申請中' },
-  { value: 'planning', label: '申請予定' },
-];
-
-const DISABILITY_CATEGORY_OPTIONS = [
-  { value: 'physical_handbook', label: '身体障害者手帳' },
-  { value: 'intellectual_handbook', label: '療育手帳' },
-  { value: 'mental_health_handbook', label: '精神障害者保健福祉手帳' },
-  { value: 'disability_basic_pension', label: '障害基礎年金' },
-  { value: 'other_disability_pension', label: 'その他の障害年金' },
-  { value: 'public_assistance', label: '生活保護' },
-];
-
-const APPLICATION_STATUS_OPTIONS = [
-  { value: 'acquired', label: '取得済み' },
-  { value: 'applying', label: '申請中' },
-  { value: 'planning', label: '申請予定' },
-  { value: 'not_applicable', label: '該当なし' },
-];
-
-const PHYSICAL_DISABILITY_TYPE_OPTIONS = [
-  { value: 'visual', label: '視覚障害' },
-  { value: 'hearing', label: '聴覚障害' },
-  { value: 'limb', label: '肢体不自由' },
-  { value: 'internal', label: '内部障害' },
-  { value: 'other', label: 'その他' },
-];
-
-const RELATIONSHIP_OPTIONS = [
-  '父', '母', '配偶者', '子', '兄弟姉妹', '相談支援専門員', 'ケースワーカー', '医療機関', '友人・知人', 'その他'
-];
-
-// 等級・レベル選択肢
-const GRADE_LEVEL_OPTIONS = {
-  physical_handbook: [
-    { value: '1', label: '1級' },
-    { value: '2', label: '2級' },
-    { value: '3', label: '3級' },
-    { value: '4', label: '4級' },
-    { value: '5', label: '5級' },
-    { value: '6', label: '6級' },
-  ],
-  intellectual_handbook: [
-    { value: 'A', label: 'A（重度）' },
-    { value: 'B1', label: 'B1（中度）' },
-    { value: 'B2', label: 'B2（軽度）' },
-    { value: 'C', label: 'C（境界域）' },
-  ],
-  mental_health_handbook: [
-    { value: '1', label: '1級' },
-    { value: '2', label: '2級' },
-    { value: '3', label: '3級' },
-  ],
-  disability_basic_pension: [
-    { value: '1', label: '1級' },
-    { value: '2', label: '2級' },
-  ],
-  other_disability_pension: [
-    { value: '1', label: '1級' },
-    { value: '2', label: '2級' },
-    { value: '3', label: '3級' },
-  ],
-  public_assistance: [
-    { value: '介護扶助', label: '介護扶助' },
-    { value: '医療扶助', label: '医療扶助' },
-    { value: '生活扶助', label: '生活扶助' },
-    { value: 'その他', label: 'その他' },
-  ],
-};
-
 const SENIOR_RECIPIENT_FORM_CLASS =
   'space-y-8 [&_h1]:text-4xl [&_h1]:font-bold [&_h2]:text-2xl [&_h2]:font-bold [&_h3]:text-2xl [&_h3]:font-bold [&_h4]:text-xl [&_h4]:font-bold [&_p]:text-base [&_p]:font-semibold [&_label]:text-lg [&_label]:font-bold [&_input]:text-lg [&_input]:font-semibold [&_input]:px-4 [&_input]:py-3 [&_select]:text-lg [&_select]:font-semibold [&_select]:px-4 [&_select]:py-3 [&_textarea]:text-lg [&_textarea]:font-semibold [&_textarea]:px-4 [&_textarea]:py-3 [&_button]:text-lg [&_button]:font-bold';
 
 export default function UserRegistrationForm() {
   const [currentSection, setCurrentSection] = useState(0);
-  const [formData, setFormData] = useState<FormData>(INITIAL_FORM_DATA);
+  const {
+    formData,
+    setFormData,
+    addEmergencyContact,
+    removeEmergencyContact,
+    addDisabilityDetail,
+    removeDisabilityDetail,
+    handleBasicInfoChange,
+    handleContactAddressChange,
+    handleEmergencyContactChange,
+    handleDisabilityInfoChange,
+    handleDisabilityDetailChange,
+  } = useRecipientFormState(INITIAL_RECIPIENT_FORM_DATA);
   const [isLoading, setIsLoading] = useState(false);
   const [errors, setErrors] = useState<Record<string, string>>({});
   const router = useRouter();
 
   // Employee Action Request Modal state
   const [isRequestModalOpen, setIsRequestModalOpen] = useState(false);
-  const [pendingFormData, setPendingFormData] = useState<FormData | null>(null);
+  const [pendingFormData, setPendingFormData] = useState<RecipientFormData | null>(null);
 
   const { isEmployee } = useStaffRole();
 
-  const sections = [
-    { id: 0, title: '基本情報', description: '氏名・ふりがな・生年月日・性別' },
-    { id: 1, title: '連絡先・住所情報', description: '住所・居住形態・交通手段・電話番号' },
-    { id: 2, title: '緊急連絡先', description: '緊急時の連絡先情報' },
-    { id: 3, title: '障害・疾患情報', description: '障害または疾患名・生活保護受給状況' },
-    { id: 4, title: '手帳・年金詳細', description: '各種手帳・年金の詳細情報' },
-  ];
+  const sections = RECIPIENT_FORM_SECTIONS;
 
   // Progress calculation
   const getProgressPercentage = () => {
@@ -287,45 +99,11 @@ export default function UserRegistrationForm() {
       ...prev,
       disabilityDetails: [createEmptyDisabilityDetail()],
     }));
-  }, [currentSection, formData.disabilityDetails.length]);
+  }, [currentSection, formData.disabilityDetails.length, setFormData]);
 
   // Form validation for each section
   const validateSection = (sectionId: number): boolean => {
-    const newErrors: Record<string, string> = {};
-
-    switch (sectionId) {
-      case 0: // Basic Information
-        if (!formData.basicInfo.firstName) newErrors.firstName = '名は必須です';
-        if (!formData.basicInfo.lastName) newErrors.lastName = '姓は必須です';
-        if (!formData.basicInfo.firstNameFurigana) newErrors.firstNameFurigana = '名（ふりがな）は必須です';
-        if (!formData.basicInfo.lastNameFurigana) newErrors.lastNameFurigana = '姓（ふりがな）は必須です';
-        if (!formData.basicInfo.birthDay) newErrors.birthDay = '生年月日は必須です';
-        if (!formData.basicInfo.gender) newErrors.gender = '性別は必須です';
-        break;
-      case 1: // Contact & Address
-        if (!formData.contactAddress.address) newErrors.address = '住所は必須です';
-        if (!formData.contactAddress.formOfResidence) newErrors.formOfResidence = '居住形態は必須です';
-        if (!formData.contactAddress.meansOfTransportation) newErrors.meansOfTransportation = '交通手段は必須です';
-        if (!formData.contactAddress.tel) newErrors.tel = '電話番号は必須です';
-        break;
-      case 2: // Emergency Contact
-        formData.emergencyContacts.forEach((contact, index) => {
-          if (!contact.firstName) newErrors[`emergencyContact${index}FirstName`] = '緊急連絡先 名は必須です';
-          if (!contact.lastName) newErrors[`emergencyContact${index}LastName`] = '緊急連絡先 姓は必須です';
-          if (!contact.firstNameFurigana) newErrors[`emergencyContact${index}FirstNameFurigana`] = '緊急連絡先 名（ふりがな）は必須です';
-          if (!contact.lastNameFurigana) newErrors[`emergencyContact${index}LastNameFurigana`] = '緊急連絡先 姓（ふりがな）は必須です';
-          if (!contact.tel) newErrors[`emergencyContact${index}Tel`] = '緊急連絡先 電話番号は必須です';
-        });
-        break;
-      case 3: // Disability Info
-        if (!formData.disabilityInfo.disabilityOrDiseaseName) newErrors.disabilityOrDiseaseName = '障害または疾患名は必須です';
-        if (!formData.disabilityInfo.livelihoodProtection) newErrors.livelihoodProtection = '生活保護受給状況は必須です';
-        break;
-      case 4: // Disability Details
-        // Optional validation for disability details
-        break;
-    }
-
+    const newErrors = validateRecipientFormSection(formData, sectionId, 'registration');
     setErrors(newErrors);
     return Object.keys(newErrors).length === 0;
   };
@@ -362,7 +140,7 @@ export default function UserRegistrationForm() {
     await executeSubmit(formData);
   };
 
-  const executeSubmit = async (data: FormData) => {
+  const executeSubmit = async (data: RecipientFormData) => {
     setIsLoading(true);
     try {
       // Import the API client and transformer
@@ -381,7 +159,6 @@ export default function UserRegistrationForm() {
         setErrors({ submit: '登録に失敗しました。もう一度お試しください。' });
       }
     } catch (error) {
-      console.error('Form submission error:', error);
       if (error instanceof Error) {
         const translatedMessage = translateErrorMessage(error.message);
         setErrors({ submit: translatedMessage || '登録に失敗しました。もう一度お試しください。' });
@@ -396,102 +173,6 @@ export default function UserRegistrationForm() {
   const handleRequestSuccess = () => {
     // リクエスト送信成功時の処理
     router.push('/dashboard?message=' + encodeURIComponent('利用者登録リクエストを送信しました。Manager/Ownerの承認をお待ちください。'));
-  };
-
-  // Add emergency contact
-  const addEmergencyContact = () => {
-    if (formData.emergencyContacts.length < 3) {
-      setFormData(prev => ({
-        ...prev,
-        emergencyContacts: [...prev.emergencyContacts, {
-          firstName: '',
-          lastName: '',
-          firstNameFurigana: '',
-          lastNameFurigana: '',
-          relationship: '',
-          tel: '',
-          address: '',
-          notes: '',
-          priority: prev.emergencyContacts.length + 1,
-        }],
-      }));
-    }
-  };
-
-  // Remove emergency contact
-  const removeEmergencyContact = (index: number) => {
-    if (formData.emergencyContacts.length > 1) {
-      setFormData(prev => ({
-        ...prev,
-        emergencyContacts: prev.emergencyContacts.filter((_, i) => i !== index),
-      }));
-    }
-  };
-
-  // Add disability detail
-  const addDisabilityDetail = () => {
-    setFormData(prev => ({
-      ...prev,
-      disabilityDetails: [...prev.disabilityDetails, createEmptyDisabilityDetail()],
-    }));
-  };
-
-  // Remove disability detail
-  const removeDisabilityDetail = (index: number) => {
-    if (formData.disabilityDetails.length > 1) {
-      setFormData(prev => ({
-        ...prev,
-        disabilityDetails: prev.disabilityDetails.filter((_, i) => i !== index),
-      }));
-    }
-  };
-
-  // Input handlers
-  const handleBasicInfoChange = (field: keyof BasicInfoData, value: string) => {
-    setFormData(prev => ({
-      ...prev,
-      basicInfo: { ...prev.basicInfo, [field]: value },
-    }));
-  };
-
-  const handleContactAddressChange = (field: keyof ContactAddressData, value: string) => {
-    setFormData(prev => ({
-      ...prev,
-      contactAddress: { ...prev.contactAddress, [field]: value },
-    }));
-  };
-
-  const handleEmergencyContactChange = (index: number, field: keyof EmergencyContactData, value: string) => {
-    setFormData(prev => ({
-      ...prev,
-      emergencyContacts: prev.emergencyContacts.map((contact, i) =>
-        i === index ? { ...contact, [field]: value } : contact
-      ),
-    }));
-  };
-
-  const handleDisabilityInfoChange = (field: keyof DisabilityInfoData, value: string) => {
-    setFormData(prev => ({
-      ...prev,
-      disabilityInfo: { ...prev.disabilityInfo, [field]: value },
-    }));
-  };
-
-  const handleDisabilityDetailChange = (index: number, field: keyof DisabilityDetailData, value: string) => {
-    setFormData(prev => ({
-      ...prev,
-      disabilityDetails: prev.disabilityDetails.map((detail, i) => {
-        if (i === index) {
-          const updatedDetail = { ...detail, [field]: value };
-          // カテゴリが変更された場合、等級・レベルをリセット
-          if (field === 'category') {
-            updatedDetail.gradeOrLevel = '';
-          }
-          return updatedDetail;
-        }
-        return detail;
-      }),
-    }));
   };
 
   return (
@@ -540,532 +221,48 @@ export default function UserRegistrationForm() {
         {/* Form Content */}
         <div className="bg-white dark:bg-[#0f1419cc] rounded-lg border border-slate-300 dark:border-[#2a3441] p-8">
           {currentSection === 0 && (
-            <div className="space-y-6">
-              <h3 className="text-lg font-semibold text-slate-950 dark:text-white mb-4">基本情報</h3>
-
-              <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
-                <div>
-                  <label className="block text-sm font-medium text-slate-700 dark:text-gray-300 mb-2">
-                    姓 <span className="text-red-400">*</span>
-                  </label>
-                  <input
-                    type="text"
-                    value={formData.basicInfo.lastName}
-                    onChange={(e) => handleBasicInfoChange('lastName', e.target.value)}
-                    className={`w-full px-3 py-2 bg-white dark:bg-[#1a1f2e] border rounded-lg text-slate-900 dark:text-white placeholder-slate-500 dark:placeholder-gray-500 focus:outline-none focus:ring-2 focus:ring-[#10b981] ${
-                      errors.lastName ? 'border-red-500' : 'border-slate-300 dark:border-[#2a3441]'
-                    }`}
-                    placeholder="山田"
-                  />
-                  {errors.lastName && <p className="text-red-400 text-sm mt-1">{errors.lastName}</p>}
-                </div>
-
-                <div>
-                  <label className="block text-sm font-medium text-slate-700 dark:text-gray-300 mb-2">
-                    名 <span className="text-red-400">*</span>
-                  </label>
-                  <input
-                    type="text"
-                    value={formData.basicInfo.firstName}
-                    onChange={(e) => handleBasicInfoChange('firstName', e.target.value)}
-                    className={`w-full px-3 py-2 bg-white dark:bg-[#1a1f2e] border rounded-lg text-slate-900 dark:text-white placeholder-slate-500 dark:placeholder-gray-500 focus:outline-none focus:ring-2 focus:ring-[#10b981] ${
-                      errors.firstName ? 'border-red-500' : 'border-slate-300 dark:border-[#2a3441]'
-                    }`}
-                    placeholder="太郎"
-                  />
-                  {errors.firstName && <p className="text-red-400 text-sm mt-1">{errors.firstName}</p>}
-                </div>
-
-                <div>
-                  <label className="block text-sm font-medium text-slate-700 dark:text-gray-300 mb-2">
-                    姓（ふりがな） <span className="text-red-400">*</span>
-                  </label>
-                  <input
-                    type="text"
-                    value={formData.basicInfo.lastNameFurigana}
-                    onChange={(e) => handleBasicInfoChange('lastNameFurigana', e.target.value)}
-                    className={`w-full px-3 py-2 bg-white dark:bg-[#1a1f2e] border rounded-lg text-slate-900 dark:text-white placeholder-slate-500 dark:placeholder-gray-500 focus:outline-none focus:ring-2 focus:ring-[#10b981] ${
-                      errors.lastNameFurigana ? 'border-red-500' : 'border-slate-300 dark:border-[#2a3441]'
-                    }`}
-                    placeholder="やまだ"
-                  />
-                  {errors.lastNameFurigana && <p className="text-red-400 text-sm mt-1">{errors.lastNameFurigana}</p>}
-                </div>
-
-                <div>
-                  <label className="block text-sm font-medium text-slate-700 dark:text-gray-300 mb-2">
-                    名（ふりがな） <span className="text-red-400">*</span>
-                  </label>
-                  <input
-                    type="text"
-                    value={formData.basicInfo.firstNameFurigana}
-                    onChange={(e) => handleBasicInfoChange('firstNameFurigana', e.target.value)}
-                    className={`w-full px-3 py-2 bg-white dark:bg-[#1a1f2e] border rounded-lg text-slate-900 dark:text-white placeholder-slate-500 dark:placeholder-gray-500 focus:outline-none focus:ring-2 focus:ring-[#10b981] ${
-                      errors.firstNameFurigana ? 'border-red-500' : 'border-slate-300 dark:border-[#2a3441]'
-                    }`}
-                    placeholder="たろう"
-                  />
-                  {errors.firstNameFurigana && <p className="text-red-400 text-sm mt-1">{errors.firstNameFurigana}</p>}
-                </div>
-
-                <div>
-                  <label className="block text-sm font-medium text-slate-700 dark:text-gray-300 mb-2">
-                    生年月日 <span className="text-red-400">*</span>
-                  </label>
-                  <DateDrumPicker
-                    value={formData.basicInfo.birthDay}
-                    onChange={(date) => handleBasicInfoChange('birthDay', date)}
-                    error={!!errors.birthDay}
-                    minYear={1900}
-                    maxYear={new Date().getFullYear()}
-                  />
-                  {errors.birthDay && <p className="text-red-400 text-sm mt-1">{errors.birthDay}</p>}
-                </div>
-
-                <div>
-                  <label className="block text-sm font-medium text-slate-700 dark:text-gray-300 mb-2">
-                    性別 <span className="text-red-400">*</span>
-                  </label>
-                  <select
-                    value={formData.basicInfo.gender}
-                    onChange={(e) => handleBasicInfoChange('gender', e.target.value)}
-                    className={`w-full px-3 py-2 bg-white dark:bg-[#1a1f2e] border rounded-lg text-slate-900 dark:text-white focus:outline-none focus:ring-2 focus:ring-[#10b981] ${
-                      errors.gender ? 'border-red-500' : 'border-slate-300 dark:border-[#2a3441]'
-                    }`}
-                  >
-                    <option value="">選択してください</option>
-                    {GENDER_OPTIONS.map(option => (
-                      <option key={option.value} value={option.value}>{option.label}</option>
-                    ))}
-                  </select>
-                  {errors.gender && <p className="text-red-400 text-sm mt-1">{errors.gender}</p>}
-                </div>
-              </div>
-            </div>
+            <BasicInfoSection
+              formData={formData}
+              errors={errors}
+              handleBasicInfoChange={handleBasicInfoChange}
+            />
           )}
 
           {currentSection === 1 && (
-            <div className="space-y-6">
-              <h3 className="text-lg font-semibold text-slate-950 dark:text-white mb-4">連絡先・住所情報</h3>
-
-              <div>
-                <label className="block text-sm font-medium text-slate-700 dark:text-gray-300 mb-2">
-                  住所 <span className="text-red-400">*</span>
-                </label>
-                <textarea
-                  value={formData.contactAddress.address}
-                  onChange={(e) => handleContactAddressChange('address', e.target.value)}
-                  rows={3}
-                  className={`w-full px-3 py-2 bg-white dark:bg-[#1a1f2e] border rounded-lg text-slate-900 dark:text-white placeholder-slate-500 dark:placeholder-gray-500 focus:outline-none focus:ring-2 focus:ring-[#10b981] ${
-                    errors.address ? 'border-red-500' : 'border-slate-300 dark:border-[#2a3441]'
-                  }`}
-                  placeholder="例：東京都新宿区西新宿1-1-1"
-                />
-                {errors.address && <p className="text-red-400 text-sm mt-1">{errors.address}</p>}
-              </div>
-
-              <div>
-                <label className="block text-sm font-medium text-slate-700 dark:text-gray-300 mb-2">
-                  居住形態 <span className="text-red-400">*</span>
-                </label>
-                <select
-                  value={formData.contactAddress.formOfResidence}
-                  onChange={(e) => handleContactAddressChange('formOfResidence', e.target.value)}
-                  className={`w-full px-3 py-2 bg-white dark:bg-[#1a1f2e] border rounded-lg text-slate-900 dark:text-white focus:outline-none focus:ring-2 focus:ring-[#10b981] ${
-                    errors.formOfResidence ? 'border-red-500' : 'border-slate-300 dark:border-[#2a3441]'
-                  }`}
-                >
-                  <option value="">選択してください</option>
-                  {FORM_OF_RESIDENCE_OPTIONS.map(option => (
-                    <option key={option.value} value={option.value}>{option.label}</option>
-                  ))}
-                </select>
-                {errors.formOfResidence && <p className="text-red-400 text-sm mt-1">{errors.formOfResidence}</p>}
-              </div>
-
-              {formData.contactAddress.formOfResidence === 'other' && (
-                <div>
-                  <label className="block text-sm font-medium text-slate-700 dark:text-gray-300 mb-2">その他詳細</label>
-                  <input
-                    type="text"
-                    value={formData.contactAddress.formOfResidenceOtherText || ''}
-                    onChange={(e) => handleContactAddressChange('formOfResidenceOtherText', e.target.value)}
-                    className="w-full px-3 py-2 bg-white dark:bg-[#1a1f2e] border border-slate-300 dark:border-[#2a3441] rounded-lg text-slate-900 dark:text-white placeholder-slate-500 dark:placeholder-gray-500 focus:outline-none focus:ring-2 focus:ring-[#10b981]"
-                    placeholder="詳細を入力してください"
-                  />
-                </div>
-              )}
-
-              <div>
-                <label className="block text-sm font-medium text-slate-700 dark:text-gray-300 mb-2">
-                  交通手段 <span className="text-red-400">*</span>
-                </label>
-                <select
-                  value={formData.contactAddress.meansOfTransportation}
-                  onChange={(e) => handleContactAddressChange('meansOfTransportation', e.target.value)}
-                  className={`w-full px-3 py-2 bg-white dark:bg-[#1a1f2e] border rounded-lg text-slate-900 dark:text-white focus:outline-none focus:ring-2 focus:ring-[#10b981] ${
-                    errors.meansOfTransportation ? 'border-red-500' : 'border-slate-300 dark:border-[#2a3441]'
-                  }`}
-                >
-                  <option value="">選択してください</option>
-                  {MEANS_OF_TRANSPORTATION_OPTIONS.map(option => (
-                    <option key={option.value} value={option.value}>{option.label}</option>
-                  ))}
-                </select>
-                {errors.meansOfTransportation && <p className="text-red-400 text-sm mt-1">{errors.meansOfTransportation}</p>}
-              </div>
-
-              {formData.contactAddress.meansOfTransportation === 'other' && (
-                <div>
-                  <label className="block text-sm font-medium text-slate-700 dark:text-gray-300 mb-2">その他詳細</label>
-                  <input
-                    type="text"
-                    value={formData.contactAddress.meansOfTransportationOtherText || ''}
-                    onChange={(e) => handleContactAddressChange('meansOfTransportationOtherText', e.target.value)}
-                    className="w-full px-3 py-2 bg-white dark:bg-[#1a1f2e] border border-slate-300 dark:border-[#2a3441] rounded-lg text-slate-900 dark:text-white placeholder-slate-500 dark:placeholder-gray-500 focus:outline-none focus:ring-2 focus:ring-[#10b981]"
-                    placeholder="詳細を入力してください"
-                  />
-                </div>
-              )}
-
-              <div>
-                <label className="block text-sm font-medium text-slate-700 dark:text-gray-300 mb-2">
-                  電話番号 <span className="text-red-400">*</span>
-                </label>
-                <input
-                  type="tel"
-                  value={formData.contactAddress.tel}
-                  onChange={(e) => handleContactAddressChange('tel', e.target.value)}
-                  className={`w-full px-3 py-2 bg-white dark:bg-[#1a1f2e] border rounded-lg text-slate-900 dark:text-white placeholder-slate-500 dark:placeholder-gray-500 focus:outline-none focus:ring-2 focus:ring-[#10b981] ${
-                    errors.tel ? 'border-red-500' : 'border-slate-300 dark:border-[#2a3441]'
-                  }`}
-                  placeholder="例：090-1234-5678"
-                />
-                {errors.tel && <p className="text-red-400 text-sm mt-1">{errors.tel}</p>}
-              </div>
-            </div>
+            <ContactSection
+              formData={formData}
+              errors={errors}
+              handleContactAddressChange={handleContactAddressChange}
+            />
           )}
 
           {currentSection === 2 && (
-            <div className="space-y-6">
-              <div className="flex items-center justify-between mb-4">
-                <h3 className="text-lg font-semibold text-slate-950 dark:text-white">緊急連絡先情報</h3>
-                <button
-                  onClick={addEmergencyContact}
-                  disabled={formData.emergencyContacts.length >= 3}
-                  className="bg-[#10b981] hover:bg-[#0f9f6e] disabled:bg-gray-600 disabled:cursor-not-allowed text-white px-4 py-2 rounded-lg text-sm font-medium transition-colors"
-                >
-                  + 連絡先を追加
-                </button>
-              </div>
-
-              {formData.emergencyContacts.map((contact, index) => (
-                <div key={index} className="border border-slate-300 dark:border-[#2a3441] rounded-lg p-6 relative">
-                  {formData.emergencyContacts.length > 1 && (
-                    <button
-                      onClick={() => removeEmergencyContact(index)}
-                      className="absolute top-4 right-4 px-3 py-1 bg-red-600/20 hover:bg-red-600/30 text-red-400 hover:text-red-300 rounded text-sm transition-colors"
-                    >
-                      削除
-                    </button>
-                  )}
-
-                  <h4 className="text-md font-medium text-slate-900 dark:text-white mb-4">緊急連絡先 {index + 1}</h4>
-
-                  <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
-                    <div>
-                      <label className="block text-sm font-medium text-slate-700 dark:text-gray-300 mb-2">
-                        姓 <span className="text-red-400">*</span>
-                      </label>
-                      <input
-                        type="text"
-                        value={contact.lastName}
-                        onChange={(e) => handleEmergencyContactChange(index, 'lastName', e.target.value)}
-                        className={`w-full px-3 py-2 bg-white dark:bg-[#1a1f2e] border rounded-lg text-slate-900 dark:text-white placeholder-slate-500 dark:placeholder-gray-500 focus:outline-none focus:ring-2 focus:ring-[#10b981] ${
-                          errors[`emergencyContact${index}LastName`] ? 'border-red-500' : 'border-slate-300 dark:border-[#2a3441]'
-                        }`}
-                        placeholder="田中"
-                      />
-                      {errors[`emergencyContact${index}LastName`] && (
-                        <p className="text-red-400 text-sm mt-1">{errors[`emergencyContact${index}LastName`]}</p>
-                      )}
-                    </div>
-
-                    <div>
-                      <label className="block text-sm font-medium text-slate-700 dark:text-gray-300 mb-2">
-                        名 <span className="text-red-400">*</span>
-                      </label>
-                      <input
-                        type="text"
-                        value={contact.firstName}
-                        onChange={(e) => handleEmergencyContactChange(index, 'firstName', e.target.value)}
-                        className={`w-full px-3 py-2 bg-white dark:bg-[#1a1f2e] border rounded-lg text-slate-900 dark:text-white placeholder-slate-500 dark:placeholder-gray-500 focus:outline-none focus:ring-2 focus:ring-[#10b981] ${
-                          errors[`emergencyContact${index}FirstName`] ? 'border-red-500' : 'border-slate-300 dark:border-[#2a3441]'
-                        }`}
-                        placeholder="花子"
-                      />
-                      {errors[`emergencyContact${index}FirstName`] && (
-                        <p className="text-red-400 text-sm mt-1">{errors[`emergencyContact${index}FirstName`]}</p>
-                      )}
-                    </div>
-
-                    <div>
-                      <label className="block text-sm font-medium text-slate-700 dark:text-gray-300 mb-2">
-                        姓（ふりがな） <span className="text-red-400">*</span>
-                      </label>
-                      <input
-                        type="text"
-                        value={contact.lastNameFurigana}
-                        onChange={(e) => handleEmergencyContactChange(index, 'lastNameFurigana', e.target.value)}
-                        className={`w-full px-3 py-2 bg-white dark:bg-[#1a1f2e] border rounded-lg text-slate-900 dark:text-white placeholder-slate-500 dark:placeholder-gray-500 focus:outline-none focus:ring-2 focus:ring-[#10b981] ${
-                          errors[`emergencyContact${index}LastNameFurigana`] ? 'border-red-500' : 'border-slate-300 dark:border-[#2a3441]'
-                        }`}
-                        placeholder="たなか"
-                      />
-                      {errors[`emergencyContact${index}LastNameFurigana`] && (
-                        <p className="text-red-400 text-sm mt-1">{errors[`emergencyContact${index}LastNameFurigana`]}</p>
-                      )}
-                    </div>
-
-                    <div>
-                      <label className="block text-sm font-medium text-slate-700 dark:text-gray-300 mb-2">
-                        名（ふりがな） <span className="text-red-400">*</span>
-                      </label>
-                      <input
-                        type="text"
-                        value={contact.firstNameFurigana}
-                        onChange={(e) => handleEmergencyContactChange(index, 'firstNameFurigana', e.target.value)}
-                        className={`w-full px-3 py-2 bg-white dark:bg-[#1a1f2e] border rounded-lg text-slate-900 dark:text-white placeholder-slate-500 dark:placeholder-gray-500 focus:outline-none focus:ring-2 focus:ring-[#10b981] ${
-                          errors[`emergencyContact${index}FirstNameFurigana`] ? 'border-red-500' : 'border-slate-300 dark:border-[#2a3441]'
-                        }`}
-                        placeholder="はなこ"
-                      />
-                      {errors[`emergencyContact${index}FirstNameFurigana`] && (
-                        <p className="text-red-400 text-sm mt-1">{errors[`emergencyContact${index}FirstNameFurigana`]}</p>
-                      )}
-                    </div>
-
-                    <div>
-                      <label className="block text-sm font-medium text-slate-700 dark:text-gray-300 mb-2">続柄・関係性</label>
-                      <select
-                        value={contact.relationship}
-                        onChange={(e) => handleEmergencyContactChange(index, 'relationship', e.target.value)}
-                        className="w-full px-3 py-2 bg-white dark:bg-[#1a1f2e] border border-slate-300 dark:border-[#2a3441] rounded-lg text-slate-900 dark:text-white focus:outline-none focus:ring-2 focus:ring-[#10b981]"
-                      >
-                        <option value="">選択してください</option>
-                        {RELATIONSHIP_OPTIONS.map(option => (
-                          <option key={option} value={option}>{option}</option>
-                        ))}
-                      </select>
-                    </div>
-
-                    <div>
-                      <label className="block text-sm font-medium text-slate-700 dark:text-gray-300 mb-2">
-                        電話番号 <span className="text-red-400">*</span>
-                      </label>
-                      <input
-                        type="tel"
-                        value={contact.tel}
-                        onChange={(e) => handleEmergencyContactChange(index, 'tel', e.target.value)}
-                        className={`w-full px-3 py-2 bg-white dark:bg-[#1a1f2e] border rounded-lg text-slate-900 dark:text-white placeholder-slate-500 dark:placeholder-gray-500 focus:outline-none focus:ring-2 focus:ring-[#10b981] ${
-                          errors[`emergencyContact${index}Tel`] ? 'border-red-500' : 'border-slate-300 dark:border-[#2a3441]'
-                        }`}
-                        placeholder="例：090-1234-5678"
-                      />
-                      {errors[`emergencyContact${index}Tel`] && (
-                        <p className="text-red-400 text-sm mt-1">{errors[`emergencyContact${index}Tel`]}</p>
-                      )}
-                    </div>
-                  </div>
-
-                  <div className="mt-4">
-                    <label className="block text-sm font-medium text-slate-700 dark:text-gray-300 mb-2">住所</label>
-                    <input
-                      type="text"
-                      value={contact.address || ''}
-                      onChange={(e) => handleEmergencyContactChange(index, 'address', e.target.value)}
-                      className="w-full px-3 py-2 bg-white dark:bg-[#1a1f2e] border border-slate-300 dark:border-[#2a3441] rounded-lg text-slate-900 dark:text-white placeholder-slate-500 dark:placeholder-gray-500 focus:outline-none focus:ring-2 focus:ring-[#10b981]"
-                      placeholder="住所（任意）"
-                    />
-                  </div>
-
-                  <div className="mt-4">
-                    <label className="block text-sm font-medium text-slate-700 dark:text-gray-300 mb-2">備考</label>
-                    <textarea
-                      value={contact.notes || ''}
-                      onChange={(e) => handleEmergencyContactChange(index, 'notes', e.target.value)}
-                      rows={2}
-                      className="w-full px-3 py-2 bg-white dark:bg-[#1a1f2e] border border-slate-300 dark:border-[#2a3441] rounded-lg text-slate-900 dark:text-white placeholder-slate-500 dark:placeholder-gray-500 focus:outline-none focus:ring-2 focus:ring-[#10b981]"
-                      placeholder="備考（任意）"
-                    />
-                  </div>
-                </div>
-              ))}
-            </div>
+            <EmergencyContactsSection
+              mode="registration"
+              formData={formData}
+              errors={errors}
+              addEmergencyContact={addEmergencyContact}
+              removeEmergencyContact={removeEmergencyContact}
+              handleEmergencyContactChange={handleEmergencyContactChange}
+            />
           )}
 
           {currentSection === 3 && (
-            <div className="space-y-6">
-              <h3 className="text-lg font-semibold text-slate-950 dark:text-white mb-4">障害・疾患情報</h3>
-
-              <div>
-                <label className="block text-sm font-medium text-slate-700 dark:text-gray-300 mb-2">
-                  障害または疾患名 <span className="text-red-400">*</span>
-                </label>
-                <textarea
-                  value={formData.disabilityInfo.disabilityOrDiseaseName}
-                  onChange={(e) => handleDisabilityInfoChange('disabilityOrDiseaseName', e.target.value)}
-                  rows={3}
-                  className={`w-full px-3 py-2 bg-white dark:bg-[#1a1f2e] border rounded-lg text-slate-900 dark:text-white placeholder-slate-500 dark:placeholder-gray-500 focus:outline-none focus:ring-2 focus:ring-[#10b981] ${
-                    errors.disabilityOrDiseaseName ? 'border-red-500' : 'border-slate-300 dark:border-[#2a3441]'
-                  }`}
-                  placeholder="例：統合失調症、知的障害、身体障害など"
-                />
-                {errors.disabilityOrDiseaseName && <p className="text-red-400 text-sm mt-1">{errors.disabilityOrDiseaseName}</p>}
-              </div>
-
-              <div>
-                <label className="block text-sm font-medium text-slate-700 dark:text-gray-300 mb-2">
-                  生活保護受給状況 <span className="text-red-400">*</span>
-                </label>
-                <select
-                  value={formData.disabilityInfo.livelihoodProtection}
-                  onChange={(e) => handleDisabilityInfoChange('livelihoodProtection', e.target.value)}
-                  className={`w-full px-3 py-2 bg-white dark:bg-[#1a1f2e] border rounded-lg text-slate-900 dark:text-white focus:outline-none focus:ring-2 focus:ring-[#10b981] ${
-                    errors.livelihoodProtection ? 'border-red-500' : 'border-slate-300 dark:border-[#2a3441]'
-                  }`}
-                >
-                  <option value="">選択してください</option>
-                  {LIVELIHOOD_PROTECTION_OPTIONS.map(option => (
-                    <option key={option.value} value={option.value}>{option.label}</option>
-                  ))}
-                </select>
-                {errors.livelihoodProtection && <p className="text-red-400 text-sm mt-1">{errors.livelihoodProtection}</p>}
-              </div>
-
-              <div>
-                <label className="block text-sm font-medium text-slate-700 dark:text-gray-300 mb-2">特記事項</label>
-                <textarea
-                  value={formData.disabilityInfo.specialRemarks || ''}
-                  onChange={(e) => handleDisabilityInfoChange('specialRemarks', e.target.value)}
-                  rows={4}
-                  maxLength={2000}
-                  className="w-full px-3 py-2 bg-white dark:bg-[#1a1f2e] border border-slate-300 dark:border-[#2a3441] rounded-lg text-slate-900 dark:text-white placeholder-slate-500 dark:placeholder-gray-500 focus:outline-none focus:ring-2 focus:ring-[#10b981]"
-                  placeholder="手帳情報以外の重要な障害特性、配慮事項、医療的ケアの必要性等（2000文字以内）"
-                />
-                <div className="text-right text-xs text-slate-600 dark:text-gray-400 mt-1">
-                  {(formData.disabilityInfo.specialRemarks || '').length}/2000文字
-                </div>
-              </div>
-            </div>
+            <DisabilitySection
+              formData={formData}
+              errors={errors}
+              handleDisabilityInfoChange={handleDisabilityInfoChange}
+            />
           )}
 
           {currentSection === 4 && (
-            <div className="space-y-6">
-              <div className="flex items-center justify-between mb-4">
-                <h3 className="text-lg font-semibold text-slate-950 dark:text-white">手帳・年金詳細情報</h3>
-                <button
-                  onClick={addDisabilityDetail}
-                  className="bg-[#10b981] hover:bg-[#0f9f6e] text-white px-4 py-2 rounded-lg text-sm font-medium transition-colors"
-                >
-                  + 手帳・年金情報を追加
-                </button>
-              </div>
-
-              {formData.disabilityDetails.map((detail, index) => (
-                <div key={index} className="border border-slate-300 dark:border-[#2a3441] rounded-lg p-6 relative">
-                  {formData.disabilityDetails.length > 1 && (
-                    <button
-                      onClick={() => removeDisabilityDetail(index)}
-                      className="absolute top-4 right-4 px-3 py-1 bg-red-600/20 hover:bg-red-600/30 text-red-400 hover:text-red-300 rounded text-sm transition-colors"
-                    >
-                      削除
-                    </button>
-                  )}
-
-                  <h4 className="text-md font-medium text-slate-900 dark:text-white mb-4">手帳・年金情報 {index + 1}</h4>
-
-                  <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
-                    <div className="md:col-span-2">
-                      <label className="block text-sm font-medium text-slate-700 dark:text-gray-300 mb-2">
-                        カテゴリ <span className="text-red-400">*</span>
-                      </label>
-                      <select
-                        value={detail.category}
-                        onChange={(e) => handleDisabilityDetailChange(index, 'category', e.target.value)}
-                        className="w-full px-3 py-2 bg-white dark:bg-[#1a1f2e] border border-slate-300 dark:border-[#2a3441] rounded-lg text-slate-900 dark:text-white focus:outline-none focus:ring-2 focus:ring-[#10b981]"
-                      >
-                        <option value="">選択してください</option>
-                        {DISABILITY_CATEGORY_OPTIONS.map(option => (
-                          <option key={option.value} value={option.value}>{option.label}</option>
-                        ))}
-                      </select>
-                    </div>
-
-                    <div>
-                      <label className="block text-sm font-medium text-slate-700 dark:text-gray-300 mb-2">等級・レベル</label>
-                      <select
-                        value={detail.gradeOrLevel || ''}
-                        onChange={(e) => handleDisabilityDetailChange(index, 'gradeOrLevel', e.target.value)}
-                        className="w-full px-3 py-2 bg-white dark:bg-[#1a1f2e] border border-slate-300 dark:border-[#2a3441] rounded-lg text-slate-900 dark:text-white focus:outline-none focus:ring-2 focus:ring-[#10b981]"
-                      >
-                        <option value="">選択してください</option>
-                        {detail.category && GRADE_LEVEL_OPTIONS[detail.category as keyof typeof GRADE_LEVEL_OPTIONS]?.map(option => (
-                          <option key={option.value} value={option.value}>{option.label}</option>
-                        ))}
-                      </select>
-                    </div>
-
-                    <div>
-                      <label className="block text-sm font-medium text-slate-700 dark:text-gray-300 mb-2">
-                        申請状況 <span className="text-red-400">*</span>
-                      </label>
-                      <select
-                        value={detail.applicationStatus}
-                        onChange={(e) => handleDisabilityDetailChange(index, 'applicationStatus', e.target.value)}
-                        className="w-full px-3 py-2 bg-white dark:bg-[#1a1f2e] border border-slate-300 dark:border-[#2a3441] rounded-lg text-slate-900 dark:text-white focus:outline-none focus:ring-2 focus:ring-[#10b981]"
-                      >
-                        <option value="">選択してください</option>
-                        {APPLICATION_STATUS_OPTIONS.map(option => (
-                          <option key={option.value} value={option.value}>{option.label}</option>
-                        ))}
-                      </select>
-                    </div>
-
-                    {detail.category === 'physical_handbook' && (
-                      <>
-                        <div>
-                          <label className="block text-sm font-medium text-slate-700 dark:text-gray-300 mb-2">身体障害種別</label>
-                          <select
-                            value={detail.physicalDisabilityType || ''}
-                            onChange={(e) => handleDisabilityDetailChange(index, 'physicalDisabilityType', e.target.value)}
-                            className="w-full px-3 py-2 bg-white dark:bg-[#1a1f2e] border border-slate-300 dark:border-[#2a3441] rounded-lg text-slate-900 dark:text-white focus:outline-none focus:ring-2 focus:ring-[#10b981]"
-                          >
-                            <option value="">選択してください</option>
-                            {PHYSICAL_DISABILITY_TYPE_OPTIONS.map(option => (
-                              <option key={option.value} value={option.value}>{option.label}</option>
-                            ))}
-                          </select>
-                        </div>
-
-                        {detail.physicalDisabilityType === 'other' && (
-                          <div>
-                            <label className="block text-sm font-medium text-slate-700 dark:text-gray-300 mb-2">その他詳細</label>
-                            <input
-                              type="text"
-                              value={detail.physicalDisabilityTypeOtherText || ''}
-                              onChange={(e) => handleDisabilityDetailChange(index, 'physicalDisabilityTypeOtherText', e.target.value)}
-                              className="w-full px-3 py-2 bg-white dark:bg-[#1a1f2e] border border-slate-300 dark:border-[#2a3441] rounded-lg text-slate-900 dark:text-white placeholder-slate-500 dark:placeholder-gray-500 focus:outline-none focus:ring-2 focus:ring-[#10b981]"
-                              placeholder="詳細を入力してください"
-                            />
-                          </div>
-                        )}
-                      </>
-                    )}
-                  </div>
-                </div>
-              ))}
-            </div>
+            <DisabilityDetailsSection
+              mode="registration"
+              formData={formData}
+              addDisabilityDetail={addDisabilityDetail}
+              removeDisabilityDetail={removeDisabilityDetail}
+              handleDisabilityDetailChange={handleDisabilityDetailChange}
+            />
           )}
 
           {errors.submit && (

--- a/components/protected/recipients/forms/BasicInfoSection.tsx
+++ b/components/protected/recipients/forms/BasicInfoSection.tsx
@@ -1,0 +1,117 @@
+import DateDrumPicker from '../../../ui/DateDrumPicker';
+
+import { GENDER_OPTIONS } from './recipientFormOptions';
+import type { RecipientFormSectionBaseProps } from './recipientFormSectionProps';
+
+export default function BasicInfoSection({
+  formData,
+  errors,
+  handleBasicInfoChange,
+}: Pick<RecipientFormSectionBaseProps, 'formData' | 'errors' | 'handleBasicInfoChange'>) {
+  return (
+    <div className="space-y-6">
+      <h3 className="text-lg font-semibold text-slate-950 dark:text-white mb-4">基本情報</h3>
+
+      <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
+        <div>
+          <label className="block text-sm font-medium text-slate-700 dark:text-gray-300 mb-2">
+            姓 <span className="text-red-400">*</span>
+          </label>
+          <input
+            type="text"
+            value={formData.basicInfo.lastName}
+            onChange={(e) => handleBasicInfoChange('lastName', e.target.value)}
+            className={`w-full px-3 py-2 bg-white dark:bg-[#1a1f2e] border rounded-lg text-slate-900 dark:text-white placeholder-slate-500 dark:placeholder-gray-500 focus:outline-none focus:ring-2 focus:ring-[#10b981] ${
+              errors.lastName ? 'border-red-500' : 'border-slate-300 dark:border-[#2a3441]'
+            }`}
+            placeholder="山田"
+          />
+          {errors.lastName && <p className="text-red-400 text-sm mt-1">{errors.lastName}</p>}
+        </div>
+
+        <div>
+          <label className="block text-sm font-medium text-slate-700 dark:text-gray-300 mb-2">
+            名 <span className="text-red-400">*</span>
+          </label>
+          <input
+            type="text"
+            value={formData.basicInfo.firstName}
+            onChange={(e) => handleBasicInfoChange('firstName', e.target.value)}
+            className={`w-full px-3 py-2 bg-white dark:bg-[#1a1f2e] border rounded-lg text-slate-900 dark:text-white placeholder-slate-500 dark:placeholder-gray-500 focus:outline-none focus:ring-2 focus:ring-[#10b981] ${
+              errors.firstName ? 'border-red-500' : 'border-slate-300 dark:border-[#2a3441]'
+            }`}
+            placeholder="太郎"
+          />
+          {errors.firstName && <p className="text-red-400 text-sm mt-1">{errors.firstName}</p>}
+        </div>
+
+        <div>
+          <label className="block text-sm font-medium text-slate-700 dark:text-gray-300 mb-2">
+            姓（ふりがな） <span className="text-red-400">*</span>
+          </label>
+          <input
+            type="text"
+            value={formData.basicInfo.lastNameFurigana}
+            onChange={(e) => handleBasicInfoChange('lastNameFurigana', e.target.value)}
+            className={`w-full px-3 py-2 bg-white dark:bg-[#1a1f2e] border rounded-lg text-slate-900 dark:text-white placeholder-slate-500 dark:placeholder-gray-500 focus:outline-none focus:ring-2 focus:ring-[#10b981] ${
+              errors.lastNameFurigana ? 'border-red-500' : 'border-slate-300 dark:border-[#2a3441]'
+            }`}
+            placeholder="やまだ"
+          />
+          {errors.lastNameFurigana && <p className="text-red-400 text-sm mt-1">{errors.lastNameFurigana}</p>}
+        </div>
+
+        <div>
+          <label className="block text-sm font-medium text-slate-700 dark:text-gray-300 mb-2">
+            名（ふりがな） <span className="text-red-400">*</span>
+          </label>
+          <input
+            type="text"
+            value={formData.basicInfo.firstNameFurigana}
+            onChange={(e) => handleBasicInfoChange('firstNameFurigana', e.target.value)}
+            className={`w-full px-3 py-2 bg-white dark:bg-[#1a1f2e] border rounded-lg text-slate-900 dark:text-white placeholder-slate-500 dark:placeholder-gray-500 focus:outline-none focus:ring-2 focus:ring-[#10b981] ${
+              errors.firstNameFurigana ? 'border-red-500' : 'border-slate-300 dark:border-[#2a3441]'
+            }`}
+            placeholder="たろう"
+          />
+          {errors.firstNameFurigana && <p className="text-red-400 text-sm mt-1">{errors.firstNameFurigana}</p>}
+        </div>
+
+        <div>
+          <label className="block text-sm font-medium text-slate-700 dark:text-gray-300 mb-2">
+            生年月日 <span className="text-red-400">*</span>
+          </label>
+          <DateDrumPicker
+            value={formData.basicInfo.birthDay}
+            onChange={(date) => handleBasicInfoChange('birthDay', date)}
+            error={!!errors.birthDay}
+            minYear={1900}
+            maxYear={new Date().getFullYear()}
+          />
+          {errors.birthDay && <p className="text-red-400 text-sm mt-1">{errors.birthDay}</p>}
+        </div>
+
+        <div>
+          <label className="block text-sm font-medium text-slate-700 dark:text-gray-300 mb-2">
+            性別 <span className="text-red-400">*</span>
+          </label>
+          <select
+            value={formData.basicInfo.gender}
+            onChange={(e) => handleBasicInfoChange('gender', e.target.value)}
+            className={`w-full px-3 py-2 bg-white dark:bg-[#1a1f2e] border rounded-lg text-slate-900 dark:text-white focus:outline-none focus:ring-2 focus:ring-[#10b981] ${
+              errors.gender ? 'border-red-500' : 'border-slate-300 dark:border-[#2a3441]'
+            }`}
+          >
+            <option value="">選択してください</option>
+            {GENDER_OPTIONS.map((option) => (
+              <option key={option.value} value={option.value}>
+                {option.label}
+              </option>
+            ))}
+          </select>
+          {errors.gender && <p className="text-red-400 text-sm mt-1">{errors.gender}</p>}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/components/protected/recipients/forms/ContactSection.tsx
+++ b/components/protected/recipients/forms/ContactSection.tsx
@@ -1,0 +1,117 @@
+import {
+  FORM_OF_RESIDENCE_OPTIONS,
+  MEANS_OF_TRANSPORTATION_OPTIONS,
+} from './recipientFormOptions';
+import type { RecipientFormSectionBaseProps } from './recipientFormSectionProps';
+
+export default function ContactSection({
+  formData,
+  errors,
+  handleContactAddressChange,
+}: Pick<RecipientFormSectionBaseProps, 'formData' | 'errors' | 'handleContactAddressChange'>) {
+  return (
+    <div className="space-y-6">
+      <h3 className="text-lg font-semibold text-slate-950 dark:text-white mb-4">連絡先・住所情報</h3>
+
+      <div>
+        <label className="block text-sm font-medium text-slate-700 dark:text-gray-300 mb-2">
+          住所 <span className="text-red-400">*</span>
+        </label>
+        <textarea
+          value={formData.contactAddress.address}
+          onChange={(e) => handleContactAddressChange('address', e.target.value)}
+          rows={3}
+          className={`w-full px-3 py-2 bg-white dark:bg-[#1a1f2e] border rounded-lg text-slate-900 dark:text-white placeholder-slate-500 dark:placeholder-gray-500 focus:outline-none focus:ring-2 focus:ring-[#10b981] ${
+            errors.address ? 'border-red-500' : 'border-slate-300 dark:border-[#2a3441]'
+          }`}
+          placeholder="例：東京都新宿区西新宿1-1-1"
+        />
+        {errors.address && <p className="text-red-400 text-sm mt-1">{errors.address}</p>}
+      </div>
+
+      <div>
+        <label className="block text-sm font-medium text-slate-700 dark:text-gray-300 mb-2">
+          居住形態 <span className="text-red-400">*</span>
+        </label>
+        <select
+          value={formData.contactAddress.formOfResidence}
+          onChange={(e) => handleContactAddressChange('formOfResidence', e.target.value)}
+          className={`w-full px-3 py-2 bg-white dark:bg-[#1a1f2e] border rounded-lg text-slate-900 dark:text-white focus:outline-none focus:ring-2 focus:ring-[#10b981] ${
+            errors.formOfResidence ? 'border-red-500' : 'border-slate-300 dark:border-[#2a3441]'
+          }`}
+        >
+          <option value="">選択してください</option>
+          {FORM_OF_RESIDENCE_OPTIONS.map((option) => (
+            <option key={option.value} value={option.value}>
+              {option.label}
+            </option>
+          ))}
+        </select>
+        {errors.formOfResidence && <p className="text-red-400 text-sm mt-1">{errors.formOfResidence}</p>}
+      </div>
+
+      {formData.contactAddress.formOfResidence === 'other' && (
+        <div>
+          <label className="block text-sm font-medium text-slate-700 dark:text-gray-300 mb-2">その他詳細</label>
+          <input
+            type="text"
+            value={formData.contactAddress.formOfResidenceOtherText || ''}
+            onChange={(e) => handleContactAddressChange('formOfResidenceOtherText', e.target.value)}
+            className="w-full px-3 py-2 bg-white dark:bg-[#1a1f2e] border border-slate-300 dark:border-[#2a3441] rounded-lg text-slate-900 dark:text-white placeholder-slate-500 dark:placeholder-gray-500 focus:outline-none focus:ring-2 focus:ring-[#10b981]"
+            placeholder="詳細を入力してください"
+          />
+        </div>
+      )}
+
+      <div>
+        <label className="block text-sm font-medium text-slate-700 dark:text-gray-300 mb-2">
+          交通手段 <span className="text-red-400">*</span>
+        </label>
+        <select
+          value={formData.contactAddress.meansOfTransportation}
+          onChange={(e) => handleContactAddressChange('meansOfTransportation', e.target.value)}
+          className={`w-full px-3 py-2 bg-white dark:bg-[#1a1f2e] border rounded-lg text-slate-900 dark:text-white focus:outline-none focus:ring-2 focus:ring-[#10b981] ${
+            errors.meansOfTransportation ? 'border-red-500' : 'border-slate-300 dark:border-[#2a3441]'
+          }`}
+        >
+          <option value="">選択してください</option>
+          {MEANS_OF_TRANSPORTATION_OPTIONS.map((option) => (
+            <option key={option.value} value={option.value}>
+              {option.label}
+            </option>
+          ))}
+        </select>
+        {errors.meansOfTransportation && <p className="text-red-400 text-sm mt-1">{errors.meansOfTransportation}</p>}
+      </div>
+
+      {formData.contactAddress.meansOfTransportation === 'other' && (
+        <div>
+          <label className="block text-sm font-medium text-slate-700 dark:text-gray-300 mb-2">その他詳細</label>
+          <input
+            type="text"
+            value={formData.contactAddress.meansOfTransportationOtherText || ''}
+            onChange={(e) => handleContactAddressChange('meansOfTransportationOtherText', e.target.value)}
+            className="w-full px-3 py-2 bg-white dark:bg-[#1a1f2e] border border-slate-300 dark:border-[#2a3441] rounded-lg text-slate-900 dark:text-white placeholder-slate-500 dark:placeholder-gray-500 focus:outline-none focus:ring-2 focus:ring-[#10b981]"
+            placeholder="詳細を入力してください"
+          />
+        </div>
+      )}
+
+      <div>
+        <label className="block text-sm font-medium text-slate-700 dark:text-gray-300 mb-2">
+          電話番号 <span className="text-red-400">*</span>
+        </label>
+        <input
+          type="tel"
+          value={formData.contactAddress.tel}
+          onChange={(e) => handleContactAddressChange('tel', e.target.value)}
+          className={`w-full px-3 py-2 bg-white dark:bg-[#1a1f2e] border rounded-lg text-slate-900 dark:text-white placeholder-slate-500 dark:placeholder-gray-500 focus:outline-none focus:ring-2 focus:ring-[#10b981] ${
+            errors.tel ? 'border-red-500' : 'border-slate-300 dark:border-[#2a3441]'
+          }`}
+          placeholder="例：090-1234-5678"
+        />
+        {errors.tel && <p className="text-red-400 text-sm mt-1">{errors.tel}</p>}
+      </div>
+    </div>
+  );
+}

--- a/components/protected/recipients/forms/DisabilityDetailsSection.tsx
+++ b/components/protected/recipients/forms/DisabilityDetailsSection.tsx
@@ -1,0 +1,148 @@
+import {
+  APPLICATION_STATUS_OPTIONS,
+  DISABILITY_CATEGORY_OPTIONS,
+  GRADE_LEVEL_OPTIONS,
+  PHYSICAL_DISABILITY_TYPE_OPTIONS,
+} from './recipientFormOptions';
+import type {
+  RecipientFormMode,
+  RecipientFormSectionBaseProps,
+} from './recipientFormSectionProps';
+
+interface DisabilityDetailsSectionProps
+  extends Pick<RecipientFormSectionBaseProps, 'formData' | 'handleDisabilityDetailChange'> {
+  mode: RecipientFormMode;
+  addDisabilityDetail: () => void;
+  removeDisabilityDetail: (index: number) => void;
+}
+
+export default function DisabilityDetailsSection({
+  formData,
+  mode,
+  addDisabilityDetail,
+  removeDisabilityDetail,
+  handleDisabilityDetailChange,
+}: DisabilityDetailsSectionProps) {
+  const isRegistration = mode === 'registration';
+
+  return (
+    <div className="space-y-6">
+      <div className="flex items-center justify-between mb-4">
+        <h3 className="text-lg font-semibold text-slate-950 dark:text-white">手帳・年金詳細情報</h3>
+        <button
+          onClick={addDisabilityDetail}
+          className="bg-[#10b981] hover:bg-[#0f9f6e] text-white px-4 py-2 rounded-lg text-sm font-medium transition-colors"
+        >
+          + 手帳・年金情報を追加
+        </button>
+      </div>
+
+      {formData.disabilityDetails.map((detail, index) => (
+        <div key={index} className="border border-slate-300 dark:border-[#2a3441] rounded-lg p-6 relative">
+          {formData.disabilityDetails.length > 1 && (
+            <button
+              onClick={() => removeDisabilityDetail(index)}
+              className="absolute top-4 right-4 px-3 py-1 bg-red-600/20 hover:bg-red-600/30 text-red-400 hover:text-red-300 rounded text-sm transition-colors"
+            >
+              削除
+            </button>
+          )}
+
+          <h4 className="text-md font-medium text-slate-900 dark:text-white mb-4">手帳・年金情報 {index + 1}</h4>
+
+          <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+            <div className="md:col-span-2">
+              <label className="block text-sm font-medium text-slate-700 dark:text-gray-300 mb-2">
+                カテゴリ {isRegistration && <span className="text-red-400">*</span>}
+              </label>
+              <select
+                value={detail.category}
+                onChange={(e) => handleDisabilityDetailChange(index, 'category', e.target.value)}
+                className="w-full px-3 py-2 bg-white dark:bg-[#1a1f2e] border border-slate-300 dark:border-[#2a3441] rounded-lg text-slate-900 dark:text-white focus:outline-none focus:ring-2 focus:ring-[#10b981]"
+              >
+                <option value="">選択してください</option>
+                {DISABILITY_CATEGORY_OPTIONS.map((option) => (
+                  <option key={option.value} value={option.value}>
+                    {option.label}
+                  </option>
+                ))}
+              </select>
+            </div>
+
+            <div>
+              <label className="block text-sm font-medium text-slate-700 dark:text-gray-300 mb-2">等級・レベル</label>
+              <select
+                value={detail.gradeOrLevel || ''}
+                onChange={(e) => handleDisabilityDetailChange(index, 'gradeOrLevel', e.target.value)}
+                className="w-full px-3 py-2 bg-white dark:bg-[#1a1f2e] border border-slate-300 dark:border-[#2a3441] rounded-lg text-slate-900 dark:text-white focus:outline-none focus:ring-2 focus:ring-[#10b981]"
+              >
+                <option value="">選択してください</option>
+                {detail.category &&
+                  GRADE_LEVEL_OPTIONS[detail.category as keyof typeof GRADE_LEVEL_OPTIONS]?.map((option) => (
+                    <option key={option.value} value={option.value}>
+                      {option.label}
+                    </option>
+                  ))}
+              </select>
+            </div>
+
+            <div>
+              <label className="block text-sm font-medium text-slate-700 dark:text-gray-300 mb-2">
+                申請状況 {isRegistration && <span className="text-red-400">*</span>}
+              </label>
+              <select
+                value={detail.applicationStatus}
+                onChange={(e) => handleDisabilityDetailChange(index, 'applicationStatus', e.target.value)}
+                className="w-full px-3 py-2 bg-white dark:bg-[#1a1f2e] border border-slate-300 dark:border-[#2a3441] rounded-lg text-slate-900 dark:text-white focus:outline-none focus:ring-2 focus:ring-[#10b981]"
+              >
+                <option value="">選択してください</option>
+                {APPLICATION_STATUS_OPTIONS.map((option) => (
+                  <option key={option.value} value={option.value}>
+                    {option.label}
+                  </option>
+                ))}
+              </select>
+            </div>
+
+            {detail.category === 'physical_handbook' && (
+              <>
+                <div>
+                  <label className="block text-sm font-medium text-slate-700 dark:text-gray-300 mb-2">
+                    身体障害種別
+                  </label>
+                  <select
+                    value={detail.physicalDisabilityType || ''}
+                    onChange={(e) => handleDisabilityDetailChange(index, 'physicalDisabilityType', e.target.value)}
+                    className="w-full px-3 py-2 bg-white dark:bg-[#1a1f2e] border border-slate-300 dark:border-[#2a3441] rounded-lg text-slate-900 dark:text-white focus:outline-none focus:ring-2 focus:ring-[#10b981]"
+                  >
+                    <option value="">選択してください</option>
+                    {PHYSICAL_DISABILITY_TYPE_OPTIONS.map((option) => (
+                      <option key={option.value} value={option.value}>
+                        {option.label}
+                      </option>
+                    ))}
+                  </select>
+                </div>
+
+                {detail.physicalDisabilityType === 'other' && (
+                  <div>
+                    <label className="block text-sm font-medium text-slate-700 dark:text-gray-300 mb-2">その他詳細</label>
+                    <input
+                      type="text"
+                      value={detail.physicalDisabilityTypeOtherText || ''}
+                      onChange={(e) =>
+                        handleDisabilityDetailChange(index, 'physicalDisabilityTypeOtherText', e.target.value)
+                      }
+                      className="w-full px-3 py-2 bg-white dark:bg-[#1a1f2e] border border-slate-300 dark:border-[#2a3441] rounded-lg text-slate-900 dark:text-white placeholder-slate-500 dark:placeholder-gray-500 focus:outline-none focus:ring-2 focus:ring-[#10b981]"
+                      placeholder="詳細を入力してください"
+                    />
+                  </div>
+                )}
+              </>
+            )}
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/components/protected/recipients/forms/DisabilitySection.tsx
+++ b/components/protected/recipients/forms/DisabilitySection.tsx
@@ -1,0 +1,68 @@
+import { LIVELIHOOD_PROTECTION_OPTIONS } from './recipientFormOptions';
+import type { RecipientFormSectionBaseProps } from './recipientFormSectionProps';
+
+export default function DisabilitySection({
+  formData,
+  errors,
+  handleDisabilityInfoChange,
+}: Pick<RecipientFormSectionBaseProps, 'formData' | 'errors' | 'handleDisabilityInfoChange'>) {
+  return (
+    <div className="space-y-6">
+      <h3 className="text-lg font-semibold text-slate-950 dark:text-white mb-4">障害・疾患情報</h3>
+
+      <div>
+        <label className="block text-sm font-medium text-slate-700 dark:text-gray-300 mb-2">
+          障害または疾患名 <span className="text-red-400">*</span>
+        </label>
+        <textarea
+          value={formData.disabilityInfo.disabilityOrDiseaseName}
+          onChange={(e) => handleDisabilityInfoChange('disabilityOrDiseaseName', e.target.value)}
+          rows={3}
+          className={`w-full px-3 py-2 bg-white dark:bg-[#1a1f2e] border rounded-lg text-slate-900 dark:text-white placeholder-slate-500 dark:placeholder-gray-500 focus:outline-none focus:ring-2 focus:ring-[#10b981] ${
+            errors.disabilityOrDiseaseName ? 'border-red-500' : 'border-slate-300 dark:border-[#2a3441]'
+          }`}
+          placeholder="例：統合失調症、知的障害、身体障害など"
+        />
+        {errors.disabilityOrDiseaseName && (
+          <p className="text-red-400 text-sm mt-1">{errors.disabilityOrDiseaseName}</p>
+        )}
+      </div>
+
+      <div>
+        <label className="block text-sm font-medium text-slate-700 dark:text-gray-300 mb-2">
+          生活保護受給状況 <span className="text-red-400">*</span>
+        </label>
+        <select
+          value={formData.disabilityInfo.livelihoodProtection}
+          onChange={(e) => handleDisabilityInfoChange('livelihoodProtection', e.target.value)}
+          className={`w-full px-3 py-2 bg-white dark:bg-[#1a1f2e] border rounded-lg text-slate-900 dark:text-white focus:outline-none focus:ring-2 focus:ring-[#10b981] ${
+            errors.livelihoodProtection ? 'border-red-500' : 'border-slate-300 dark:border-[#2a3441]'
+          }`}
+        >
+          <option value="">選択してください</option>
+          {LIVELIHOOD_PROTECTION_OPTIONS.map((option) => (
+            <option key={option.value} value={option.value}>
+              {option.label}
+            </option>
+          ))}
+        </select>
+        {errors.livelihoodProtection && <p className="text-red-400 text-sm mt-1">{errors.livelihoodProtection}</p>}
+      </div>
+
+      <div>
+        <label className="block text-sm font-medium text-slate-700 dark:text-gray-300 mb-2">特記事項</label>
+        <textarea
+          value={formData.disabilityInfo.specialRemarks || ''}
+          onChange={(e) => handleDisabilityInfoChange('specialRemarks', e.target.value)}
+          rows={4}
+          maxLength={2000}
+          className="w-full px-3 py-2 bg-white dark:bg-[#1a1f2e] border border-slate-300 dark:border-[#2a3441] rounded-lg text-slate-900 dark:text-white placeholder-slate-500 dark:placeholder-gray-500 focus:outline-none focus:ring-2 focus:ring-[#10b981]"
+          placeholder="手帳情報以外の重要な障害特性、配慮事項、医療的ケアの必要性等（2000文字以内）"
+        />
+        <div className="text-right text-xs text-slate-600 dark:text-gray-400 mt-1">
+          {(formData.disabilityInfo.specialRemarks || '').length}/2000文字
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/components/protected/recipients/forms/EmergencyContactsSection.tsx
+++ b/components/protected/recipients/forms/EmergencyContactsSection.tsx
@@ -1,0 +1,187 @@
+import { RELATIONSHIP_OPTIONS } from './recipientFormOptions';
+import type {
+  RecipientFormMode,
+  RecipientFormSectionBaseProps,
+} from './recipientFormSectionProps';
+
+interface EmergencyContactsSectionProps
+  extends Pick<RecipientFormSectionBaseProps, 'formData' | 'errors' | 'handleEmergencyContactChange'> {
+  mode: RecipientFormMode;
+  addEmergencyContact: () => void;
+  removeEmergencyContact: (index: number) => void;
+}
+
+export default function EmergencyContactsSection({
+  formData,
+  errors,
+  mode,
+  addEmergencyContact,
+  removeEmergencyContact,
+  handleEmergencyContactChange,
+}: EmergencyContactsSectionProps) {
+  const isRegistration = mode === 'registration';
+
+  return (
+    <div className="space-y-6">
+      <div className="flex items-center justify-between mb-4">
+        <h3 className="text-lg font-semibold text-slate-950 dark:text-white">緊急連絡先情報</h3>
+        <button
+          onClick={addEmergencyContact}
+          disabled={formData.emergencyContacts.length >= 3}
+          className="bg-[#10b981] hover:bg-[#0f9f6e] disabled:bg-gray-600 disabled:cursor-not-allowed text-white px-4 py-2 rounded-lg text-sm font-medium transition-colors"
+        >
+          + 連絡先を追加
+        </button>
+      </div>
+
+      {formData.emergencyContacts.map((contact, index) => (
+        <div key={index} className="border border-slate-300 dark:border-[#2a3441] rounded-lg p-6 relative">
+          {formData.emergencyContacts.length > 1 && (
+            <button
+              onClick={() => removeEmergencyContact(index)}
+              className="absolute top-4 right-4 px-3 py-1 bg-red-600/20 hover:bg-red-600/30 text-red-400 hover:text-red-300 rounded text-sm transition-colors"
+            >
+              削除
+            </button>
+          )}
+
+          <h4 className="text-md font-medium text-slate-900 dark:text-white mb-4">緊急連絡先 {index + 1}</h4>
+
+          <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+            <div>
+              <label className="block text-sm font-medium text-slate-700 dark:text-gray-300 mb-2">
+                姓 <span className="text-red-400">*</span>
+              </label>
+              <input
+                type="text"
+                value={contact.lastName}
+                onChange={(e) => handleEmergencyContactChange(index, 'lastName', e.target.value)}
+                className={`w-full px-3 py-2 bg-white dark:bg-[#1a1f2e] border rounded-lg text-slate-900 dark:text-white placeholder-slate-500 dark:placeholder-gray-500 focus:outline-none focus:ring-2 focus:ring-[#10b981] ${
+                  errors[`emergencyContact${index}LastName`] ? 'border-red-500' : 'border-slate-300 dark:border-[#2a3441]'
+                }`}
+                placeholder="田中"
+              />
+              {errors[`emergencyContact${index}LastName`] && (
+                <p className="text-red-400 text-sm mt-1">{errors[`emergencyContact${index}LastName`]}</p>
+              )}
+            </div>
+
+            <div>
+              <label className="block text-sm font-medium text-slate-700 dark:text-gray-300 mb-2">
+                名 <span className="text-red-400">*</span>
+              </label>
+              <input
+                type="text"
+                value={contact.firstName}
+                onChange={(e) => handleEmergencyContactChange(index, 'firstName', e.target.value)}
+                className={`w-full px-3 py-2 bg-white dark:bg-[#1a1f2e] border rounded-lg text-slate-900 dark:text-white placeholder-slate-500 dark:placeholder-gray-500 focus:outline-none focus:ring-2 focus:ring-[#10b981] ${
+                  errors[`emergencyContact${index}FirstName`] ? 'border-red-500' : 'border-slate-300 dark:border-[#2a3441]'
+                }`}
+                placeholder="花子"
+              />
+              {errors[`emergencyContact${index}FirstName`] && (
+                <p className="text-red-400 text-sm mt-1">{errors[`emergencyContact${index}FirstName`]}</p>
+              )}
+            </div>
+
+            <div>
+              <label className="block text-sm font-medium text-slate-700 dark:text-gray-300 mb-2">
+                姓（ふりがな） {isRegistration && <span className="text-red-400">*</span>}
+              </label>
+              <input
+                type="text"
+                value={contact.lastNameFurigana}
+                onChange={(e) => handleEmergencyContactChange(index, 'lastNameFurigana', e.target.value)}
+                className={`w-full px-3 py-2 bg-white dark:bg-[#1a1f2e] border rounded-lg text-slate-900 dark:text-white placeholder-slate-500 dark:placeholder-gray-500 focus:outline-none focus:ring-2 focus:ring-[#10b981] ${
+                  isRegistration && errors[`emergencyContact${index}LastNameFurigana`]
+                    ? 'border-red-500'
+                    : 'border-slate-300 dark:border-[#2a3441]'
+                }`}
+                placeholder="たなか"
+              />
+              {isRegistration && errors[`emergencyContact${index}LastNameFurigana`] && (
+                <p className="text-red-400 text-sm mt-1">{errors[`emergencyContact${index}LastNameFurigana`]}</p>
+              )}
+            </div>
+
+            <div>
+              <label className="block text-sm font-medium text-slate-700 dark:text-gray-300 mb-2">
+                名（ふりがな） {isRegistration && <span className="text-red-400">*</span>}
+              </label>
+              <input
+                type="text"
+                value={contact.firstNameFurigana}
+                onChange={(e) => handleEmergencyContactChange(index, 'firstNameFurigana', e.target.value)}
+                className={`w-full px-3 py-2 bg-white dark:bg-[#1a1f2e] border rounded-lg text-slate-900 dark:text-white placeholder-slate-500 dark:placeholder-gray-500 focus:outline-none focus:ring-2 focus:ring-[#10b981] ${
+                  isRegistration && errors[`emergencyContact${index}FirstNameFurigana`]
+                    ? 'border-red-500'
+                    : 'border-slate-300 dark:border-[#2a3441]'
+                }`}
+                placeholder="はなこ"
+              />
+              {isRegistration && errors[`emergencyContact${index}FirstNameFurigana`] && (
+                <p className="text-red-400 text-sm mt-1">{errors[`emergencyContact${index}FirstNameFurigana`]}</p>
+              )}
+            </div>
+
+            <div>
+              <label className="block text-sm font-medium text-slate-700 dark:text-gray-300 mb-2">続柄・関係性</label>
+              <select
+                value={contact.relationship}
+                onChange={(e) => handleEmergencyContactChange(index, 'relationship', e.target.value)}
+                className="w-full px-3 py-2 bg-white dark:bg-[#1a1f2e] border border-slate-300 dark:border-[#2a3441] rounded-lg text-slate-900 dark:text-white focus:outline-none focus:ring-2 focus:ring-[#10b981]"
+              >
+                <option value="">選択してください</option>
+                {RELATIONSHIP_OPTIONS.map((option) => (
+                  <option key={option} value={option}>
+                    {option}
+                  </option>
+                ))}
+              </select>
+            </div>
+
+            <div>
+              <label className="block text-sm font-medium text-slate-700 dark:text-gray-300 mb-2">
+                電話番号 <span className="text-red-400">*</span>
+              </label>
+              <input
+                type="tel"
+                value={contact.tel}
+                onChange={(e) => handleEmergencyContactChange(index, 'tel', e.target.value)}
+                className={`w-full px-3 py-2 bg-white dark:bg-[#1a1f2e] border rounded-lg text-slate-900 dark:text-white placeholder-slate-500 dark:placeholder-gray-500 focus:outline-none focus:ring-2 focus:ring-[#10b981] ${
+                  errors[`emergencyContact${index}Tel`] ? 'border-red-500' : 'border-slate-300 dark:border-[#2a3441]'
+                }`}
+                placeholder="例：090-1234-5678"
+              />
+              {errors[`emergencyContact${index}Tel`] && (
+                <p className="text-red-400 text-sm mt-1">{errors[`emergencyContact${index}Tel`]}</p>
+              )}
+            </div>
+          </div>
+
+          <div className="mt-4">
+            <label className="block text-sm font-medium text-slate-700 dark:text-gray-300 mb-2">住所</label>
+            <input
+              type="text"
+              value={contact.address || ''}
+              onChange={(e) => handleEmergencyContactChange(index, 'address', e.target.value)}
+              className="w-full px-3 py-2 bg-white dark:bg-[#1a1f2e] border border-slate-300 dark:border-[#2a3441] rounded-lg text-slate-900 dark:text-white placeholder-slate-500 dark:placeholder-gray-500 focus:outline-none focus:ring-2 focus:ring-[#10b981]"
+              placeholder="住所（任意）"
+            />
+          </div>
+
+          <div className="mt-4">
+            <label className="block text-sm font-medium text-slate-700 dark:text-gray-300 mb-2">備考</label>
+            <textarea
+              value={contact.notes || ''}
+              onChange={(e) => handleEmergencyContactChange(index, 'notes', e.target.value)}
+              rows={2}
+              className="w-full px-3 py-2 bg-white dark:bg-[#1a1f2e] border border-slate-300 dark:border-[#2a3441] rounded-lg text-slate-900 dark:text-white placeholder-slate-500 dark:placeholder-gray-500 focus:outline-none focus:ring-2 focus:ring-[#10b981]"
+              placeholder="備考（任意）"
+            />
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/components/protected/recipients/forms/FamilyMemberForm.tsx
+++ b/components/protected/recipients/forms/FamilyMemberForm.tsx
@@ -39,7 +39,7 @@ export default function FamilyMemberForm({
       }
       onSuccess();
     } catch (err) {
-      console.error('Failed to save family member:', err);
+      console.error('Client operation failed');
       if (err instanceof Error) {
         setError(err.message);
       } else {

--- a/components/protected/recipients/forms/FamilyMemberList.tsx
+++ b/components/protected/recipients/forms/FamilyMemberList.tsx
@@ -45,7 +45,7 @@ export default function FamilyMemberList({
       await assessmentApi.familyMembers.delete(id);
       onRefresh();
     } catch (err) {
-      console.error('Failed to delete family member:', err);
+      console.error('Client operation failed');
       alert('家族情報の削除に失敗しました。');
     } finally {
       setDeletingId(null);

--- a/components/protected/recipients/forms/HospitalVisitForm.tsx
+++ b/components/protected/recipients/forms/HospitalVisitForm.tsx
@@ -45,7 +45,7 @@ export default function HospitalVisitForm({
       }
       onSuccess();
     } catch (err) {
-      console.error('Failed to save hospital visit:', err);
+      console.error('Client operation failed');
       if (err instanceof Error) {
         setError(err.message);
       } else {

--- a/components/protected/recipients/forms/HospitalVisitList.tsx
+++ b/components/protected/recipients/forms/HospitalVisitList.tsx
@@ -41,7 +41,7 @@ export default function HospitalVisitList({
       await assessmentApi.hospitalVisits.delete(id);
       onRefresh();
     } catch (err) {
-      console.error('Failed to delete hospital visit:', err);
+      console.error('Client operation failed');
       alert('通院歴の削除に失敗しました。');
     } finally {
       setDeletingId(null);

--- a/components/protected/recipients/forms/MedicalInfoForm.tsx
+++ b/components/protected/recipients/forms/MedicalInfoForm.tsx
@@ -34,7 +34,7 @@ export default function MedicalInfoForm({
       await assessmentApi.medicalInfo.createOrUpdate(recipientId, formData);
       onSuccess();
     } catch (err) {
-      console.error('Failed to save medical info:', err);
+      console.error('Client operation failed');
       if (err instanceof Error) {
         setError(err.message);
       } else {

--- a/components/protected/recipients/forms/ServiceHistoryForm.tsx
+++ b/components/protected/recipients/forms/ServiceHistoryForm.tsx
@@ -39,7 +39,7 @@ export default function ServiceHistoryForm({
       }
       onSuccess();
     } catch (err) {
-      console.error('Failed to save service history:', err);
+      console.error('Client operation failed');
       if (err instanceof Error) {
         setError(err.message);
       } else {

--- a/components/protected/recipients/forms/ServiceHistoryList.tsx
+++ b/components/protected/recipients/forms/ServiceHistoryList.tsx
@@ -40,7 +40,7 @@ export default function ServiceHistoryList({
       await assessmentApi.serviceHistory.delete(id);
       onRefresh();
     } catch (err) {
-      console.error('Failed to delete service history:', err);
+      console.error('Client operation failed');
       alert('サービス利用歴の削除に失敗しました。');
     } finally {
       setDeletingId(null);

--- a/components/protected/recipients/forms/recipientFormDefaults.ts
+++ b/components/protected/recipients/forms/recipientFormDefaults.ts
@@ -1,0 +1,62 @@
+import type {
+  DisabilityDetailData,
+  EmergencyContactData,
+  RecipientFormData,
+  RecipientFormSection,
+} from './recipientFormTypes';
+
+export const RECIPIENT_FORM_SECTIONS: RecipientFormSection[] = [
+  { id: 0, title: '基本情報', description: '氏名・ふりがな・生年月日・性別' },
+  { id: 1, title: '連絡先・住所情報', description: '住所・居住形態・交通手段・電話番号' },
+  { id: 2, title: '緊急連絡先', description: '緊急時の連絡先情報' },
+  { id: 3, title: '障害・疾患情報', description: '障害または疾患名・生活保護受給状況' },
+  { id: 4, title: '手帳・年金詳細', description: '各種手帳・年金の詳細情報' },
+];
+
+export const createEmptyEmergencyContact = (priority = 1): EmergencyContactData => ({
+  firstName: '',
+  lastName: '',
+  firstNameFurigana: '',
+  lastNameFurigana: '',
+  relationship: '',
+  tel: '',
+  address: '',
+  notes: '',
+  priority,
+});
+
+export const createEmptyDisabilityDetail = (): DisabilityDetailData => ({
+  category: '',
+  gradeOrLevel: '',
+  physicalDisabilityType: '',
+  physicalDisabilityTypeOtherText: '',
+  applicationStatus: '',
+});
+
+export const INITIAL_RECIPIENT_FORM_DATA: RecipientFormData = {
+  basicInfo: {
+    firstName: '',
+    lastName: '',
+    firstNameFurigana: '',
+    lastNameFurigana: '',
+    birthDay: '',
+    gender: '',
+  },
+  contactAddress: {
+    address: '',
+    formOfResidence: '',
+    formOfResidenceOtherText: '',
+    meansOfTransportation: '',
+    meansOfTransportationOtherText: '',
+    tel: '',
+  },
+  emergencyContacts: [createEmptyEmergencyContact()],
+  disabilityInfo: {
+    disabilityOrDiseaseName: '',
+    livelihoodProtection: '',
+    specialRemarks: '',
+  },
+  // 手帳・年金詳細は任意項目のため初期値は空配列とする。
+  // 空エントリを持つとバックエンドの enum バリデーションで 422 エラーになる。
+  disabilityDetails: [],
+};

--- a/components/protected/recipients/forms/recipientFormMapper.test.ts
+++ b/components/protected/recipients/forms/recipientFormMapper.test.ts
@@ -1,0 +1,91 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import { mapWelfareRecipientToFormData } from './recipientFormMapper';
+import type { WelfareRecipient } from '../../../../lib/welfare-recipients';
+
+test('maps snake_case and camelCase recipient fields to form data', () => {
+  const recipient: WelfareRecipient = {
+    id: 'recipient-1',
+    first_name: '太郎',
+    last_name: '山田',
+    first_name_furigana: 'たろう',
+    last_name_furigana: 'やまだ',
+    birth_day: '1990-01-01',
+    gender: 'male',
+    detail: {
+      id: 1,
+      welfare_recipient_id: 'recipient-1',
+      address: '東京都',
+      form_of_residence: '',
+      formOfResidence: 'home_alone',
+      means_of_transportation: '',
+      meansOfTransportation: 'walk',
+      tel: '090-0000-0000',
+      emergency_contacts: [
+        {
+          id: 1,
+          first_name: '',
+          firstName: '花子',
+          last_name: '',
+          lastName: '山田',
+          first_name_furigana: '',
+          firstNameFurigana: 'はなこ',
+          last_name_furigana: '',
+          lastNameFurigana: 'やまだ',
+          relationship: '母',
+          tel: '090-1111-1111',
+          priority: 2,
+        },
+      ],
+    },
+    disability_status: {
+      id: 1,
+      welfare_recipient_id: 'recipient-1',
+      disability_or_disease_name: '',
+      disabilityOrDiseaseName: 'なし',
+      livelihood_protection: '',
+      livelihoodProtection: 'not_receiving',
+      details: [
+        {
+          id: 1,
+          disability_status_id: 1,
+          category: 'physical_handbook',
+          grade_or_level: '',
+          gradeOrLevel: '2',
+          physical_disability_type: '',
+          physicalDisabilityType: 'visual',
+          physical_disability_type_other_text: '',
+          application_status: '',
+          applicationStatus: 'acquired',
+        },
+      ],
+    },
+  };
+
+  const result = mapWelfareRecipientToFormData(recipient);
+
+  assert.equal(result.basicInfo.firstName, '太郎');
+  assert.equal(result.contactAddress.formOfResidence, 'home_alone');
+  assert.equal(result.emergencyContacts[0].firstName, '花子');
+  assert.equal(result.emergencyContacts[0].priority, 2);
+  assert.equal(result.disabilityInfo.disabilityOrDiseaseName, 'なし');
+  assert.equal(result.disabilityDetails[0].gradeOrLevel, '2');
+});
+
+test('creates editable empty rows when optional nested data is missing', () => {
+  const result = mapWelfareRecipientToFormData({
+    id: 'recipient-2',
+    first_name: '',
+    last_name: '',
+    first_name_furigana: '',
+    last_name_furigana: '',
+    birth_day: '',
+    gender: '',
+  });
+
+  assert.equal(result.emergencyContacts.length, 1);
+  assert.equal(result.emergencyContacts[0].priority, 1);
+  assert.equal(result.disabilityDetails.length, 1);
+  assert.equal(result.disabilityDetails[0].category, '');
+});

--- a/components/protected/recipients/forms/recipientFormMapper.ts
+++ b/components/protected/recipients/forms/recipientFormMapper.ts
@@ -1,0 +1,68 @@
+import type { WelfareRecipient } from '../../../../lib/welfare-recipients';
+
+import {
+  createEmptyDisabilityDetail,
+  createEmptyEmergencyContact,
+} from './recipientFormDefaults';
+import type { RecipientFormData } from './recipientFormTypes';
+
+export function mapWelfareRecipientToFormData(initialData: WelfareRecipient): RecipientFormData {
+  return {
+    basicInfo: {
+      firstName: initialData.first_name || '',
+      lastName: initialData.last_name || '',
+      firstNameFurigana: initialData.first_name_furigana || '',
+      lastNameFurigana: initialData.last_name_furigana || '',
+      birthDay: initialData.birth_day || '',
+      gender: initialData.gender || '',
+    },
+    contactAddress: {
+      address: initialData.detail?.address || '',
+      formOfResidence: initialData.detail?.formOfResidence || initialData.detail?.form_of_residence || '',
+      formOfResidenceOtherText:
+        initialData.detail?.formOfResidenceOtherText || initialData.detail?.form_of_residence_other_text || '',
+      meansOfTransportation:
+        initialData.detail?.meansOfTransportation || initialData.detail?.means_of_transportation || '',
+      meansOfTransportationOtherText:
+        initialData.detail?.meansOfTransportationOtherText ||
+        initialData.detail?.means_of_transportation_other_text ||
+        '',
+      tel: initialData.detail?.tel || '',
+    },
+    emergencyContacts: initialData.detail?.emergency_contacts?.length
+      ? initialData.detail.emergency_contacts.map((contact) => ({
+          firstName: contact.firstName || contact.first_name || '',
+          lastName: contact.lastName || contact.last_name || '',
+          firstNameFurigana: contact.firstNameFurigana || contact.first_name_furigana || '',
+          lastNameFurigana: contact.lastNameFurigana || contact.last_name_furigana || '',
+          relationship: contact.relationship || '',
+          tel: contact.tel || '',
+          address: contact.address || '',
+          notes: contact.notes || '',
+          priority: contact.priority || 1,
+        }))
+      : [createEmptyEmergencyContact()],
+    disabilityInfo: {
+      disabilityOrDiseaseName:
+        initialData.disability_status?.disabilityOrDiseaseName ||
+        initialData.disability_status?.disability_or_disease_name ||
+        '',
+      livelihoodProtection:
+        initialData.disability_status?.livelihoodProtection ||
+        initialData.disability_status?.livelihood_protection ||
+        '',
+      specialRemarks:
+        initialData.disability_status?.specialRemarks || initialData.disability_status?.special_remarks || '',
+    },
+    disabilityDetails: initialData.disability_status?.details?.length
+      ? initialData.disability_status.details.map((detail) => ({
+          category: detail.category || '',
+          gradeOrLevel: detail.gradeOrLevel || detail.grade_or_level || '',
+          physicalDisabilityType: detail.physicalDisabilityType || detail.physical_disability_type || '',
+          physicalDisabilityTypeOtherText:
+            detail.physicalDisabilityTypeOtherText || detail.physical_disability_type_other_text || '',
+          applicationStatus: detail.applicationStatus || detail.application_status || '',
+        }))
+      : [createEmptyDisabilityDetail()],
+  };
+}

--- a/components/protected/recipients/forms/recipientFormOptions.ts
+++ b/components/protected/recipients/forms/recipientFormOptions.ts
@@ -1,0 +1,107 @@
+export const GENDER_OPTIONS = [
+  { value: 'male', label: '男性' },
+  { value: 'female', label: '女性' },
+  { value: 'other', label: 'その他' },
+];
+
+export const FORM_OF_RESIDENCE_OPTIONS = [
+  { value: 'home_with_family', label: '自宅（家族と同居）' },
+  { value: 'home_alone', label: '自宅（一人暮らし）' },
+  { value: 'group_home', label: 'グループホーム' },
+  { value: 'institution', label: '入所施設' },
+  { value: 'hospital', label: '病院・医療機関' },
+  { value: 'other', label: 'その他' },
+];
+
+export const MEANS_OF_TRANSPORTATION_OPTIONS = [
+  { value: 'walk', label: '徒歩' },
+  { value: 'bicycle', label: '自転車' },
+  { value: 'motorbike', label: 'バイク・原付' },
+  { value: 'car_self', label: '自家用車（自分で運転）' },
+  { value: 'car_transport', label: '自家用車（送迎）' },
+  { value: 'public_transport', label: '公共交通機関（電車・バス）' },
+  { value: 'welfare_transport', label: '福祉輸送サービス' },
+  { value: 'other', label: 'その他' },
+];
+
+export const LIVELIHOOD_PROTECTION_OPTIONS = [
+  { value: 'not_receiving', label: 'なし' },
+  { value: 'receiving_with_allowance', label: 'あり（他人介護料有り）' },
+  { value: 'receiving_without_allowance', label: 'あり（他人介護料無し）' },
+  { value: 'applying', label: '申請中' },
+  { value: 'planning', label: '申請予定' },
+];
+
+export const DISABILITY_CATEGORY_OPTIONS = [
+  { value: 'physical_handbook', label: '身体障害者手帳' },
+  { value: 'intellectual_handbook', label: '療育手帳' },
+  { value: 'mental_health_handbook', label: '精神障害者保健福祉手帳' },
+  { value: 'disability_basic_pension', label: '障害基礎年金' },
+  { value: 'other_disability_pension', label: 'その他の障害年金' },
+  { value: 'public_assistance', label: '生活保護' },
+];
+
+export const APPLICATION_STATUS_OPTIONS = [
+  { value: 'acquired', label: '取得済み' },
+  { value: 'applying', label: '申請中' },
+  { value: 'planning', label: '申請予定' },
+  { value: 'not_applicable', label: '該当なし' },
+];
+
+export const PHYSICAL_DISABILITY_TYPE_OPTIONS = [
+  { value: 'visual', label: '視覚障害' },
+  { value: 'hearing', label: '聴覚障害' },
+  { value: 'limb', label: '肢体不自由' },
+  { value: 'internal', label: '内部障害' },
+  { value: 'other', label: 'その他' },
+];
+
+export const RELATIONSHIP_OPTIONS = [
+  '父',
+  '母',
+  '配偶者',
+  '子',
+  '兄弟姉妹',
+  '相談支援専門員',
+  'ケースワーカー',
+  '医療機関',
+  '友人・知人',
+  'その他',
+];
+
+export const GRADE_LEVEL_OPTIONS = {
+  physical_handbook: [
+    { value: '1', label: '1級' },
+    { value: '2', label: '2級' },
+    { value: '3', label: '3級' },
+    { value: '4', label: '4級' },
+    { value: '5', label: '5級' },
+    { value: '6', label: '6級' },
+  ],
+  intellectual_handbook: [
+    { value: 'A', label: 'A（重度）' },
+    { value: 'B1', label: 'B1（中度）' },
+    { value: 'B2', label: 'B2（軽度）' },
+    { value: 'C', label: 'C（境界域）' },
+  ],
+  mental_health_handbook: [
+    { value: '1', label: '1級' },
+    { value: '2', label: '2級' },
+    { value: '3', label: '3級' },
+  ],
+  disability_basic_pension: [
+    { value: '1', label: '1級' },
+    { value: '2', label: '2級' },
+  ],
+  other_disability_pension: [
+    { value: '1', label: '1級' },
+    { value: '2', label: '2級' },
+    { value: '3', label: '3級' },
+  ],
+  public_assistance: [
+    { value: '介護扶助', label: '介護扶助' },
+    { value: '医療扶助', label: '医療扶助' },
+    { value: '生活扶助', label: '生活扶助' },
+    { value: 'その他', label: 'その他' },
+  ],
+};

--- a/components/protected/recipients/forms/recipientFormSectionProps.ts
+++ b/components/protected/recipients/forms/recipientFormSectionProps.ts
@@ -1,0 +1,25 @@
+import type {
+  BasicInfoData,
+  ContactAddressData,
+  DisabilityDetailData,
+  DisabilityInfoData,
+  EmergencyContactData,
+  RecipientFormData,
+} from './recipientFormTypes';
+
+export type RecipientFormMode = 'registration' | 'edit';
+
+export type RecipientFormErrors = Record<string, string>;
+
+export interface RecipientFormHandlers {
+  handleBasicInfoChange: (field: keyof BasicInfoData, value: string) => void;
+  handleContactAddressChange: (field: keyof ContactAddressData, value: string) => void;
+  handleEmergencyContactChange: (index: number, field: keyof EmergencyContactData, value: string) => void;
+  handleDisabilityInfoChange: (field: keyof DisabilityInfoData, value: string) => void;
+  handleDisabilityDetailChange: (index: number, field: keyof DisabilityDetailData, value: string) => void;
+}
+
+export interface RecipientFormSectionBaseProps extends RecipientFormHandlers {
+  formData: RecipientFormData;
+  errors: RecipientFormErrors;
+}

--- a/components/protected/recipients/forms/recipientFormSections.test.ts
+++ b/components/protected/recipients/forms/recipientFormSections.test.ts
@@ -1,0 +1,16 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import BasicInfoSection from './BasicInfoSection';
+import ContactSection from './ContactSection';
+import DisabilityDetailsSection from './DisabilityDetailsSection';
+import DisabilitySection from './DisabilitySection';
+import EmergencyContactsSection from './EmergencyContactsSection';
+
+test('recipient form section components are exported', () => {
+  assert.equal(typeof BasicInfoSection, 'function');
+  assert.equal(typeof ContactSection, 'function');
+  assert.equal(typeof EmergencyContactsSection, 'function');
+  assert.equal(typeof DisabilitySection, 'function');
+  assert.equal(typeof DisabilityDetailsSection, 'function');
+});

--- a/components/protected/recipients/forms/recipientFormState.test.ts
+++ b/components/protected/recipients/forms/recipientFormState.test.ts
@@ -1,0 +1,53 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import {
+  addDisabilityDetailToForm,
+  addEmergencyContactToForm,
+  changeDisabilityDetailField,
+  removeDisabilityDetailFromForm,
+  removeEmergencyContactFromForm,
+  updateBasicInfoField,
+} from './recipientFormState';
+import { INITIAL_RECIPIENT_FORM_DATA } from './recipientFormDefaults';
+
+test('adds emergency contacts up to three and keeps priorities sequential', () => {
+  const second = addEmergencyContactToForm(INITIAL_RECIPIENT_FORM_DATA);
+  const third = addEmergencyContactToForm(second);
+  const stillThird = addEmergencyContactToForm(third);
+
+  assert.equal(second.emergencyContacts.length, 2);
+  assert.equal(third.emergencyContacts.length, 3);
+  assert.equal(stillThird.emergencyContacts.length, 3);
+  assert.deepEqual(third.emergencyContacts.map((contact) => contact.priority), [1, 2, 3]);
+});
+
+test('does not remove the last emergency contact or disability detail', () => {
+  const withTwoContacts = addEmergencyContactToForm(INITIAL_RECIPIENT_FORM_DATA);
+  const oneContact = removeEmergencyContactFromForm(withTwoContacts, 1);
+  const stillOneContact = removeEmergencyContactFromForm(oneContact, 0);
+
+  const withOneDetail = addDisabilityDetailToForm(INITIAL_RECIPIENT_FORM_DATA);
+  const stillOneDetail = removeDisabilityDetailFromForm(withOneDetail, 0);
+
+  assert.equal(oneContact.emergencyContacts.length, 1);
+  assert.equal(stillOneContact.emergencyContacts.length, 1);
+  assert.equal(stillOneDetail.disabilityDetails.length, 1);
+});
+
+test('updates fields immutably and resets grade when disability category changes', () => {
+  const named = updateBasicInfoField(INITIAL_RECIPIENT_FORM_DATA, 'firstName', '太郎');
+  const withDetail = changeDisabilityDetailField(
+    addDisabilityDetailToForm(INITIAL_RECIPIENT_FORM_DATA),
+    0,
+    'gradeOrLevel',
+    '2',
+  );
+  const categoryChanged = changeDisabilityDetailField(withDetail, 0, 'category', 'physical_handbook');
+
+  assert.equal(INITIAL_RECIPIENT_FORM_DATA.basicInfo.firstName, '');
+  assert.equal(named.basicInfo.firstName, '太郎');
+  assert.equal(withDetail.disabilityDetails[0].gradeOrLevel, '2');
+  assert.equal(categoryChanged.disabilityDetails[0].category, 'physical_handbook');
+  assert.equal(categoryChanged.disabilityDetails[0].gradeOrLevel, '');
+});

--- a/components/protected/recipients/forms/recipientFormState.ts
+++ b/components/protected/recipients/forms/recipientFormState.ts
@@ -1,0 +1,116 @@
+import {
+  createEmptyDisabilityDetail,
+  createEmptyEmergencyContact,
+} from './recipientFormDefaults';
+import type {
+  BasicInfoData,
+  ContactAddressData,
+  DisabilityDetailData,
+  DisabilityInfoData,
+  EmergencyContactData,
+  RecipientFormData,
+} from './recipientFormTypes';
+
+export function addEmergencyContactToForm(formData: RecipientFormData): RecipientFormData {
+  if (formData.emergencyContacts.length >= 3) return formData;
+
+  return {
+    ...formData,
+    emergencyContacts: [
+      ...formData.emergencyContacts,
+      createEmptyEmergencyContact(formData.emergencyContacts.length + 1),
+    ],
+  };
+}
+
+export function removeEmergencyContactFromForm(formData: RecipientFormData, index: number): RecipientFormData {
+  if (formData.emergencyContacts.length <= 1) return formData;
+
+  return {
+    ...formData,
+    emergencyContacts: formData.emergencyContacts.filter((_, i) => i !== index),
+  };
+}
+
+export function addDisabilityDetailToForm(formData: RecipientFormData): RecipientFormData {
+  return {
+    ...formData,
+    disabilityDetails: [...formData.disabilityDetails, createEmptyDisabilityDetail()],
+  };
+}
+
+export function removeDisabilityDetailFromForm(formData: RecipientFormData, index: number): RecipientFormData {
+  if (formData.disabilityDetails.length <= 1) return formData;
+
+  return {
+    ...formData,
+    disabilityDetails: formData.disabilityDetails.filter((_, i) => i !== index),
+  };
+}
+
+export function updateBasicInfoField(
+  formData: RecipientFormData,
+  field: keyof BasicInfoData,
+  value: string,
+): RecipientFormData {
+  return {
+    ...formData,
+    basicInfo: { ...formData.basicInfo, [field]: value },
+  };
+}
+
+export function updateContactAddressField(
+  formData: RecipientFormData,
+  field: keyof ContactAddressData,
+  value: string,
+): RecipientFormData {
+  return {
+    ...formData,
+    contactAddress: { ...formData.contactAddress, [field]: value },
+  };
+}
+
+export function updateEmergencyContactField(
+  formData: RecipientFormData,
+  index: number,
+  field: keyof EmergencyContactData,
+  value: string,
+): RecipientFormData {
+  return {
+    ...formData,
+    emergencyContacts: formData.emergencyContacts.map((contact, i) =>
+      i === index ? { ...contact, [field]: value } : contact
+    ),
+  };
+}
+
+export function updateDisabilityInfoField(
+  formData: RecipientFormData,
+  field: keyof DisabilityInfoData,
+  value: string,
+): RecipientFormData {
+  return {
+    ...formData,
+    disabilityInfo: { ...formData.disabilityInfo, [field]: value },
+  };
+}
+
+export function changeDisabilityDetailField(
+  formData: RecipientFormData,
+  index: number,
+  field: keyof DisabilityDetailData,
+  value: string,
+): RecipientFormData {
+  return {
+    ...formData,
+    disabilityDetails: formData.disabilityDetails.map((detail, i) => {
+      if (i !== index) return detail;
+
+      const updatedDetail = { ...detail, [field]: value };
+      if (field === 'category') {
+        updatedDetail.gradeOrLevel = '';
+      }
+      return updatedDetail;
+    }),
+  };
+}

--- a/components/protected/recipients/forms/recipientFormTypes.ts
+++ b/components/protected/recipients/forms/recipientFormTypes.ts
@@ -1,0 +1,59 @@
+export interface BasicInfoData {
+  firstName: string;
+  lastName: string;
+  firstNameFurigana: string;
+  lastNameFurigana: string;
+  birthDay: string;
+  gender: string;
+}
+
+export interface ContactAddressData {
+  address: string;
+  formOfResidence: string;
+  formOfResidenceOtherText?: string;
+  meansOfTransportation: string;
+  meansOfTransportationOtherText?: string;
+  tel: string;
+}
+
+export interface EmergencyContactData {
+  firstName: string;
+  lastName: string;
+  firstNameFurigana: string;
+  lastNameFurigana: string;
+  relationship: string;
+  tel: string;
+  address?: string;
+  notes?: string;
+  priority: number;
+}
+
+export interface DisabilityInfoData {
+  disabilityOrDiseaseName: string;
+  livelihoodProtection: string;
+  specialRemarks?: string;
+}
+
+export interface DisabilityDetailData {
+  category: string;
+  gradeOrLevel?: string;
+  physicalDisabilityType?: string;
+  physicalDisabilityTypeOtherText?: string;
+  applicationStatus: string;
+}
+
+export interface RecipientFormData {
+  basicInfo: BasicInfoData;
+  contactAddress: ContactAddressData;
+  emergencyContacts: EmergencyContactData[];
+  disabilityInfo: DisabilityInfoData;
+  disabilityDetails: DisabilityDetailData[];
+}
+
+export type RecipientFormSectionId = 0 | 1 | 2 | 3 | 4;
+
+export interface RecipientFormSection {
+  id: RecipientFormSectionId;
+  title: string;
+  description: string;
+}

--- a/components/protected/recipients/forms/recipientFormValidation.test.ts
+++ b/components/protected/recipients/forms/recipientFormValidation.test.ts
@@ -1,0 +1,118 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import {
+  validateRecipientFormSection,
+  type RecipientFormValidationMode,
+} from './recipientFormValidation';
+import { INITIAL_RECIPIENT_FORM_DATA } from './recipientFormDefaults';
+import type { RecipientFormData } from './recipientFormTypes';
+
+const validFormData = (): RecipientFormData => ({
+  basicInfo: {
+    firstName: '太郎',
+    lastName: '山田',
+    firstNameFurigana: 'たろう',
+    lastNameFurigana: 'やまだ',
+    birthDay: '1990-01-01',
+    gender: 'male',
+  },
+  contactAddress: {
+    address: '東京都',
+    formOfResidence: 'home_alone',
+    formOfResidenceOtherText: '',
+    meansOfTransportation: 'walk',
+    meansOfTransportationOtherText: '',
+    tel: '090-0000-0000',
+  },
+  emergencyContacts: [
+    {
+      firstName: '花子',
+      lastName: '山田',
+      firstNameFurigana: 'はなこ',
+      lastNameFurigana: 'やまだ',
+      relationship: '母',
+      tel: '090-1111-1111',
+      address: '',
+      notes: '',
+      priority: 1,
+    },
+  ],
+  disabilityInfo: {
+    disabilityOrDiseaseName: 'なし',
+    livelihoodProtection: 'not_receiving',
+    specialRemarks: '',
+  },
+  disabilityDetails: [],
+});
+
+test('registration mode keeps emergency contact furigana required', () => {
+  const formData = validFormData();
+  formData.emergencyContacts[0].firstNameFurigana = '';
+  formData.emergencyContacts[0].lastNameFurigana = '';
+
+  const result = validateRecipientFormSection(formData, 2, 'registration');
+
+  assert.deepEqual(result, {
+    emergencyContact0FirstNameFurigana: '緊急連絡先 名（ふりがな）は必須です',
+    emergencyContact0LastNameFurigana: '緊急連絡先 姓（ふりがな）は必須です',
+  });
+});
+
+test('edit mode preserves current emergency contact furigana behavior', () => {
+  const formData = validFormData();
+  formData.emergencyContacts[0].firstNameFurigana = '';
+  formData.emergencyContacts[0].lastNameFurigana = '';
+
+  const result = validateRecipientFormSection(formData, 2, 'edit');
+
+  assert.deepEqual(result, {});
+});
+
+test('required section errors match current form behavior', () => {
+  const cases: Array<{
+    sectionId: number;
+    mode: RecipientFormValidationMode;
+    expected: Record<string, string>;
+  }> = [
+    {
+      sectionId: 0,
+      mode: 'registration',
+      expected: {
+        firstName: '名は必須です',
+        lastName: '姓は必須です',
+        firstNameFurigana: '名（ふりがな）は必須です',
+        lastNameFurigana: '姓（ふりがな）は必須です',
+        birthDay: '生年月日は必須です',
+        gender: '性別は必須です',
+      },
+    },
+    {
+      sectionId: 1,
+      mode: 'registration',
+      expected: {
+        address: '住所は必須です',
+        formOfResidence: '居住形態は必須です',
+        meansOfTransportation: '交通手段は必須です',
+        tel: '電話番号は必須です',
+      },
+    },
+    {
+      sectionId: 3,
+      mode: 'edit',
+      expected: {
+        disabilityOrDiseaseName: '障害または疾患名は必須です',
+        livelihoodProtection: '生活保護受給状況は必須です',
+      },
+    },
+    {
+      sectionId: 4,
+      mode: 'edit',
+      expected: {},
+    },
+  ];
+
+  for (const { sectionId, mode, expected } of cases) {
+    assert.deepEqual(validateRecipientFormSection(INITIAL_RECIPIENT_FORM_DATA, sectionId, mode), expected);
+  }
+});

--- a/components/protected/recipients/forms/recipientFormValidation.ts
+++ b/components/protected/recipients/forms/recipientFormValidation.ts
@@ -1,0 +1,64 @@
+import type { RecipientFormData } from './recipientFormTypes';
+
+export type RecipientFormValidationMode = 'registration' | 'edit';
+
+export function validateRecipientFormSection(
+  formData: RecipientFormData,
+  sectionId: number,
+  mode: RecipientFormValidationMode,
+): Record<string, string> {
+  const newErrors: Record<string, string> = {};
+
+  switch (sectionId) {
+    case 0:
+      if (!formData.basicInfo.firstName) newErrors.firstName = '名は必須です';
+      if (!formData.basicInfo.lastName) newErrors.lastName = '姓は必須です';
+      if (!formData.basicInfo.firstNameFurigana) newErrors.firstNameFurigana = '名（ふりがな）は必須です';
+      if (!formData.basicInfo.lastNameFurigana) newErrors.lastNameFurigana = '姓（ふりがな）は必須です';
+      if (!formData.basicInfo.birthDay) newErrors.birthDay = '生年月日は必須です';
+      if (!formData.basicInfo.gender) newErrors.gender = '性別は必須です';
+      break;
+    case 1:
+      if (!formData.contactAddress.address) newErrors.address = '住所は必須です';
+      if (!formData.contactAddress.formOfResidence) newErrors.formOfResidence = '居住形態は必須です';
+      if (!formData.contactAddress.meansOfTransportation) newErrors.meansOfTransportation = '交通手段は必須です';
+      if (!formData.contactAddress.tel) newErrors.tel = '電話番号は必須です';
+      break;
+    case 2:
+      formData.emergencyContacts.forEach((contact, index) => {
+        if (!contact.firstName) {
+          newErrors[`emergencyContact${index}FirstName`] =
+            mode === 'registration' ? '緊急連絡先 名は必須です' : '名は必須です';
+        }
+        if (!contact.lastName) {
+          newErrors[`emergencyContact${index}LastName`] =
+            mode === 'registration' ? '緊急連絡先 姓は必須です' : '姓は必須です';
+        }
+        if (mode === 'registration') {
+          if (!contact.firstNameFurigana) {
+            newErrors[`emergencyContact${index}FirstNameFurigana`] = '緊急連絡先 名（ふりがな）は必須です';
+          }
+          if (!contact.lastNameFurigana) {
+            newErrors[`emergencyContact${index}LastNameFurigana`] = '緊急連絡先 姓（ふりがな）は必須です';
+          }
+        }
+        if (!contact.tel) {
+          newErrors[`emergencyContact${index}Tel`] =
+            mode === 'registration' ? '緊急連絡先 電話番号は必須です' : '電話番号は必須です';
+        }
+      });
+      break;
+    case 3:
+      if (!formData.disabilityInfo.disabilityOrDiseaseName) {
+        newErrors.disabilityOrDiseaseName = '障害または疾患名は必須です';
+      }
+      if (!formData.disabilityInfo.livelihoodProtection) {
+        newErrors.livelihoodProtection = '生活保護受給状況は必須です';
+      }
+      break;
+    case 4:
+      break;
+  }
+
+  return newErrors;
+}

--- a/components/protected/recipients/forms/useRecipientFormState.ts
+++ b/components/protected/recipients/forms/useRecipientFormState.ts
@@ -1,0 +1,66 @@
+import { type Dispatch, type SetStateAction, useCallback, useState } from 'react';
+
+import {
+  addDisabilityDetailToForm,
+  addEmergencyContactToForm,
+  changeDisabilityDetailField,
+  removeDisabilityDetailFromForm,
+  removeEmergencyContactFromForm,
+  updateBasicInfoField,
+  updateContactAddressField,
+  updateDisabilityInfoField,
+  updateEmergencyContactField,
+} from './recipientFormState';
+import type {
+  BasicInfoData,
+  ContactAddressData,
+  DisabilityDetailData,
+  DisabilityInfoData,
+  EmergencyContactData,
+  RecipientFormData,
+} from './recipientFormTypes';
+
+interface RecipientFormState<T extends RecipientFormData | null> {
+  formData: T;
+  setFormData: Dispatch<SetStateAction<T>>;
+  addEmergencyContact: () => void;
+  removeEmergencyContact: (index: number) => void;
+  addDisabilityDetail: () => void;
+  removeDisabilityDetail: (index: number) => void;
+  handleBasicInfoChange: (field: keyof BasicInfoData, value: string) => void;
+  handleContactAddressChange: (field: keyof ContactAddressData, value: string) => void;
+  handleEmergencyContactChange: (index: number, field: keyof EmergencyContactData, value: string) => void;
+  handleDisabilityInfoChange: (field: keyof DisabilityInfoData, value: string) => void;
+  handleDisabilityDetailChange: (index: number, field: keyof DisabilityDetailData, value: string) => void;
+}
+
+export function useRecipientFormState<T extends RecipientFormData | null>(
+  initialFormData: T,
+): RecipientFormState<T> {
+  const [formData, setFormData] = useState<T>(initialFormData);
+
+  const updateFormData = useCallback((updater: (current: RecipientFormData) => RecipientFormData) => {
+    setFormData((current) => (current ? (updater(current) as T) : current));
+  }, []);
+
+  return {
+    formData,
+    setFormData,
+    addEmergencyContact: () => updateFormData(addEmergencyContactToForm),
+    removeEmergencyContact: (index: number) =>
+      updateFormData((current) => removeEmergencyContactFromForm(current, index)),
+    addDisabilityDetail: () => updateFormData(addDisabilityDetailToForm),
+    removeDisabilityDetail: (index: number) =>
+      updateFormData((current) => removeDisabilityDetailFromForm(current, index)),
+    handleBasicInfoChange: (field: keyof BasicInfoData, value: string) =>
+      updateFormData((current) => updateBasicInfoField(current, field, value)),
+    handleContactAddressChange: (field: keyof ContactAddressData, value: string) =>
+      updateFormData((current) => updateContactAddressField(current, field, value)),
+    handleEmergencyContactChange: (index: number, field: keyof EmergencyContactData, value: string) =>
+      updateFormData((current) => updateEmergencyContactField(current, index, field, value)),
+    handleDisabilityInfoChange: (field: keyof DisabilityInfoData, value: string) =>
+      updateFormData((current) => updateDisabilityInfoField(current, field, value)),
+    handleDisabilityDetailChange: (index: number, field: keyof DisabilityDetailData, value: string) =>
+      updateFormData((current) => changeDisabilityDetailField(current, index, field, value)),
+  };
+}

--- a/components/protected/support_plan/PlanDeliverableModal.tsx
+++ b/components/protected/support_plan/PlanDeliverableModal.tsx
@@ -73,7 +73,7 @@ export default function PlanDeliverableModal({
           setIsLoadingPdf(false);
         })
         .catch((err) => {
-          console.error('PDF読み込みエラー:', err);
+          console.error('Client operation failed');
           setError('PDFの読み込みに失敗しました。CORS設定を確認してください。');
           setIsLoadingPdf(false);
         });

--- a/components/protected/support_plan/SupportPlan.tsx
+++ b/components/protected/support_plan/SupportPlan.tsx
@@ -46,7 +46,7 @@ export default function SupportPlan() {
         setRecipient(recipientData);
         setCycles(cyclesData.cycles || []);
       } catch (err) {
-        console.error('Failed to fetch support plan data:', err);
+        console.error('Client operation failed');
         setError('データの取得に失敗しました');
       } finally {
         setIsLoading(false);
@@ -131,7 +131,7 @@ export default function SupportPlan() {
 
       setIsModalOpen(false);
     } catch (err) {
-      console.error('Failed to upload file:', err);
+      console.error('Client operation failed');
       // エラーメッセージを表示
       toast.error('PDFのアップロードに失敗しました');
       throw err; // モーダル側でエラーハンドリング
@@ -151,7 +151,7 @@ export default function SupportPlan() {
 
       setIsModalOpen(false);
     } catch (err) {
-      console.error('Failed to reupload file:', err);
+      console.error('Client operation failed');
       // エラーメッセージを表示
       toast.error('PDFの再アップロードに失敗しました');
       throw err;
@@ -172,7 +172,7 @@ export default function SupportPlan() {
       const cyclesData = await supportPlanApi.getCycles(recipientId);
       setCycles(cyclesData.cycles || []);
     } catch (err) {
-      console.error('Failed to set monitoring deadline:', err);
+      console.error('Client operation failed');
       toast.error('モニタリング期限の設定に失敗しました。');
     }
   };

--- a/components/ui/google/CalendarLinkButton.tsx
+++ b/components/ui/google/CalendarLinkButton.tsx
@@ -177,7 +177,7 @@ export default function CalendarLinkButton() {
           setOfficeId(id);
         }
       } catch (err) {
-        console.error('Failed to fetch user office:', err);
+        console.error('Client operation failed');
       }
     };
 
@@ -194,7 +194,7 @@ export default function CalendarLinkButton() {
           const account = await calendarApi.getOfficeCalendar(officeId);
           setCalendarAccount(account);
         } catch (err) {
-          console.error('Failed to fetch calendar info:', err);
+          console.error('Client operation failed');
 
           // 404エラー（カレンダー未設定）の場合は特別扱い
           const errorMessage = err instanceof Error ? err.message : String(err);

--- a/contexts/BillingContext.tsx
+++ b/contexts/BillingContext.tsx
@@ -70,7 +70,7 @@ export function BillingProvider({ children }: BillingProviderProps) {
       const data = await billingApi.getBillingStatus();
       setBillingStatus(data);
     } catch (err) {
-      console.error('課金ステータスの取得に失敗しました:', err);
+      console.error('課金ステータスの取得に失敗しました');
       setError(err instanceof Error ? err.message : '課金ステータスの取得に失敗しました');
     } finally {
       setIsLoading(false);

--- a/hooks/dashboard/dashboardDataState.ts
+++ b/hooks/dashboard/dashboardDataState.ts
@@ -1,0 +1,15 @@
+import type { DashboardData } from '../../types/dashboard';
+
+export type DashboardDataClient = DashboardData;
+
+export function normalizeDashboardData(
+  data: DashboardData | null
+): DashboardData | null {
+  if (!data) return null;
+  if (Array.isArray(data.recipients)) return data;
+
+  return {
+    ...data,
+    recipients: [],
+  };
+}

--- a/hooks/dashboard/useDashboardData.test.ts
+++ b/hooks/dashboard/useDashboardData.test.ts
@@ -1,0 +1,28 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import {
+  normalizeDashboardData,
+  type DashboardDataClient,
+} from './dashboardDataState';
+
+test('normalizeDashboardData keeps recipients array when API returns a valid list', () => {
+  const data = {
+    recipients: [{ id: 'recipient-1' }],
+  } as unknown as DashboardDataClient;
+
+  assert.equal(normalizeDashboardData(data), data);
+  assert.deepEqual(normalizeDashboardData(data)?.recipients, [{ id: 'recipient-1' }]);
+});
+
+test('normalizeDashboardData replaces invalid recipients with an empty list', () => {
+  const data = {
+    recipients: null,
+  } as unknown as DashboardDataClient;
+
+  const normalized = normalizeDashboardData(data);
+
+  assert.notEqual(normalized, data);
+  assert.deepEqual(normalized?.recipients, []);
+  assert.equal(normalizeDashboardData(null), null);
+});

--- a/hooks/dashboard/useDashboardData.ts
+++ b/hooks/dashboard/useDashboardData.ts
@@ -1,0 +1,92 @@
+'use client';
+
+import { useCallback, useEffect, useRef, useState } from 'react';
+
+import { authApi } from '../../lib/auth';
+import { billingApi } from '../../lib/api/billing';
+import { dashboardApi, type DashboardParams } from '../../lib/dashboard';
+import { welfareRecipientsApi } from '../../lib/welfare-recipients';
+import { removeRecipientFromDashboardData } from '../../lib/permissions/dashboard';
+import { normalizeDashboardData } from './dashboardDataState';
+import type { BillingStatusResponse } from '../../types/billing';
+import type { DashboardData } from '../../types/dashboard';
+import type { StaffResponse } from '../../types/staff';
+
+export function useDashboardData() {
+  const [dashboardData, setDashboardData] = useState<DashboardData | null>(null);
+  const [staff, setStaff] = useState<StaffResponse | null>(null);
+  const [billingStatus, setBillingStatus] = useState<BillingStatusResponse | null>(null);
+  const [isLoading, setIsLoading] = useState(false);
+  const isLoadingRef = useRef(isLoading);
+
+  useEffect(() => {
+    isLoadingRef.current = isLoading;
+  }, [isLoading]);
+
+  const applyFilters = useCallback(async (filterParams: DashboardParams = {}) => {
+    if (isLoadingRef.current) return;
+
+    try {
+      setIsLoading(true);
+      const newDashboardData = await dashboardApi.getDashboardData(filterParams);
+      setDashboardData(normalizeDashboardData(newDashboardData));
+    } catch {
+    } finally {
+      setIsLoading(false);
+    }
+  }, []);
+
+  const fetchInitialData = useCallback(async () => {
+    try {
+      const [userData, data, billing] = await Promise.all([
+        authApi.getCurrentUser(),
+        dashboardApi.getDashboardData(),
+        billingApi.getBillingStatus(),
+      ]);
+      setStaff(userData);
+      setDashboardData(normalizeDashboardData(data));
+      setBillingStatus(billing);
+    } catch {
+    }
+  }, []);
+
+  const resetDashboardData = useCallback(async () => {
+    if (isLoadingRef.current) return;
+
+    try {
+      setIsLoading(true);
+      const resetData = await dashboardApi.getDashboardData();
+      setDashboardData(normalizeDashboardData(resetData));
+    } catch {
+    } finally {
+      setIsLoading(false);
+    }
+  }, []);
+
+  const deleteRecipient = useCallback(async (recipientId: string) => {
+    try {
+      setIsLoading(true);
+      await welfareRecipientsApi.delete(recipientId);
+      setDashboardData((prevData) =>
+        removeRecipientFromDashboardData(prevData, recipientId)
+      );
+      return true;
+    } catch {
+      return false;
+    } finally {
+      setIsLoading(false);
+    }
+  }, []);
+
+  return {
+    dashboardData,
+    staff,
+    billingStatus,
+    isLoading,
+    isLoadingRef,
+    applyFilters,
+    fetchInitialData,
+    resetDashboardData,
+    deleteRecipient,
+  };
+}

--- a/hooks/dashboard/useDashboardFilters.test.ts
+++ b/hooks/dashboard/useDashboardFilters.test.ts
@@ -1,0 +1,53 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import {
+  DEFAULT_DASHBOARD_FILTERS,
+  buildDashboardParams,
+  getDashboardSortButtonLabel,
+  getNextDashboardSortOrder,
+  hasDashboardFilter,
+} from './useDashboardFilters';
+
+test('buildDashboardParams maps UI filter state to dashboard API params', () => {
+  assert.deepEqual(
+    buildDashboardParams('山田', 'name_phonetic', 'desc', {
+      isOverdue: true,
+      isUpcoming: false,
+      hasAssessmentDue: true,
+      status: 'assessment',
+    }),
+    {
+      searchTerm: '山田',
+      sortBy: 'name_phonetic',
+      sortOrder: 'desc',
+      is_overdue: true,
+      is_upcoming: false,
+      has_assessment_due: true,
+      status: 'assessment',
+    }
+  );
+});
+
+test('buildDashboardParams omits empty status as undefined', () => {
+  assert.equal(
+    buildDashboardParams('', 'next_renewal_deadline', 'asc', DEFAULT_DASHBOARD_FILTERS).status,
+    undefined
+  );
+});
+
+test('getNextDashboardSortOrder toggles only when clicking the active sort field', () => {
+  assert.equal(getNextDashboardSortOrder('name_phonetic', 'asc', 'name_phonetic'), 'desc');
+  assert.equal(getNextDashboardSortOrder('next_renewal_deadline', 'desc', 'name_phonetic'), 'asc');
+});
+
+test('getDashboardSortButtonLabel matches existing button label behavior', () => {
+  assert.equal(getDashboardSortButtonLabel('name_phonetic', 'asc', 'name_phonetic'), '降順');
+  assert.equal(getDashboardSortButtonLabel('name_phonetic', 'desc', 'name_phonetic'), '昇順');
+  assert.equal(getDashboardSortButtonLabel('next_renewal_deadline', 'asc', 'name_phonetic'), '昇順');
+});
+
+test('hasDashboardFilter detects search and active filter state', () => {
+  assert.equal(hasDashboardFilter('', DEFAULT_DASHBOARD_FILTERS), false);
+  assert.equal(hasDashboardFilter('山田', DEFAULT_DASHBOARD_FILTERS), true);
+  assert.equal(hasDashboardFilter('', { ...DEFAULT_DASHBOARD_FILTERS, isUpcoming: true }), true);
+});

--- a/hooks/dashboard/useDashboardFilters.ts
+++ b/hooks/dashboard/useDashboardFilters.ts
@@ -1,0 +1,238 @@
+'use client';
+
+import { useCallback, useEffect, useMemo, useState } from 'react';
+export type DashboardSortOrder = 'asc' | 'desc';
+export type DashboardFilterKey = 'isOverdue' | 'isUpcoming' | 'hasAssessmentDue';
+
+export interface DashboardParams {
+  sortBy?: string;
+  sortOrder?: DashboardSortOrder;
+  searchTerm?: string;
+  is_overdue?: boolean;
+  is_upcoming?: boolean;
+  has_assessment_due?: boolean;
+  status?: string;
+  cycle_number?: number;
+  skip?: number;
+  limit?: number;
+}
+
+export interface DashboardFilterState {
+  isOverdue: boolean;
+  isUpcoming: boolean;
+  hasAssessmentDue: boolean;
+  status: string | null;
+}
+
+interface UseDashboardFiltersOptions {
+  initialDeadlineAlert?: boolean;
+  onApplyFilters: (params: DashboardParams) => void;
+}
+
+export const DEFAULT_DASHBOARD_FILTERS: DashboardFilterState = {
+  isOverdue: false,
+  isUpcoming: false,
+  hasAssessmentDue: false,
+  status: null,
+};
+
+export function buildDashboardParams(
+  searchTerm: string,
+  sortBy: string,
+  sortOrder: DashboardSortOrder,
+  filters: DashboardFilterState,
+  overrides: Partial<DashboardParams> = {}
+): DashboardParams {
+  return {
+    searchTerm,
+    sortBy,
+    sortOrder,
+    is_overdue: filters.isOverdue,
+    is_upcoming: filters.isUpcoming,
+    has_assessment_due: filters.hasAssessmentDue,
+    status: filters.status || undefined,
+    ...overrides,
+  };
+}
+
+export function getNextDashboardSortOrder(
+  currentSortBy: string,
+  currentSortOrder: DashboardSortOrder,
+  targetSortBy: string
+): DashboardSortOrder {
+  return currentSortBy === targetSortBy && currentSortOrder === 'asc' ? 'desc' : 'asc';
+}
+
+export function getDashboardSortButtonLabel(
+  currentSortBy: string,
+  currentSortOrder: DashboardSortOrder,
+  targetSortBy: string
+) {
+  if (currentSortBy !== targetSortBy) return '昇順';
+  return currentSortOrder === 'asc' ? '降順' : '昇順';
+}
+
+export function hasDashboardFilter(searchTerm: string, filters: DashboardFilterState) {
+  return (
+    Boolean(searchTerm) ||
+    filters.isOverdue ||
+    filters.isUpcoming ||
+    filters.hasAssessmentDue ||
+    Boolean(filters.status)
+  );
+}
+
+export function useDashboardFilters({
+  initialDeadlineAlert = false,
+  onApplyFilters,
+}: UseDashboardFiltersOptions) {
+  const [sortOrder, setSortOrder] = useState<DashboardSortOrder>('asc');
+  const [sortBy, setSortBy] = useState('next_renewal_deadline');
+  const [searchTerm, setSearchTerm] = useState('');
+  const [debouncedSearchTerm, setDebouncedSearchTerm] = useState('');
+  const [activeFilters, setActiveFilters] = useState<DashboardFilterState>(
+    initialDeadlineAlert
+      ? { ...DEFAULT_DASHBOARD_FILTERS, isUpcoming: true }
+      : DEFAULT_DASHBOARD_FILTERS
+  );
+
+  const buildParams = useCallback(
+    (
+      nextSearchTerm = searchTerm,
+      nextSortBy = sortBy,
+      nextSortOrder = sortOrder,
+      nextFilters = activeFilters,
+      overrides: Partial<DashboardParams> = {}
+    ) =>
+      buildDashboardParams(
+        nextSearchTerm,
+        nextSortBy,
+        nextSortOrder,
+        nextFilters,
+        overrides
+      ),
+    [activeFilters, searchTerm, sortBy, sortOrder]
+  );
+
+  const handleNextRenewalSortClick = useCallback(() => {
+    const nextSortBy = 'next_renewal_deadline';
+    const nextSortOrder = getNextDashboardSortOrder(sortBy, sortOrder, nextSortBy);
+    setSortBy(nextSortBy);
+    setSortOrder(nextSortOrder);
+    onApplyFilters(buildParams(searchTerm, nextSortBy, nextSortOrder, activeFilters));
+  }, [activeFilters, buildParams, onApplyFilters, searchTerm, sortBy, sortOrder]);
+
+  const handleNameSortClick = useCallback(() => {
+    const nextSortBy = 'name_phonetic';
+    const nextSortOrder = getNextDashboardSortOrder(sortBy, sortOrder, nextSortBy);
+    setSortBy(nextSortBy);
+    setSortOrder(nextSortOrder);
+    onApplyFilters(buildParams(searchTerm, nextSortBy, nextSortOrder, activeFilters));
+  }, [activeFilters, buildParams, onApplyFilters, searchTerm, sortBy, sortOrder]);
+
+  const getSortButtonLabel = useCallback(
+    (targetSortBy: string) =>
+      getDashboardSortButtonLabel(sortBy, sortOrder, targetSortBy),
+    [sortBy, sortOrder]
+  );
+
+  const handleSearch = useCallback((term: string) => {
+    setSearchTerm(term);
+  }, []);
+
+  const handleFilterToggle = useCallback(
+    (filterType: DashboardFilterKey, value: boolean) => {
+      setActiveFilters((prev) => {
+        const nextFilters = { ...prev, [filterType]: value };
+        onApplyFilters(buildParams(searchTerm, sortBy, sortOrder, nextFilters));
+        return nextFilters;
+      });
+    },
+    [buildParams, onApplyFilters, searchTerm, sortBy, sortOrder]
+  );
+
+  const handleStatusFilter = useCallback(
+    (status: string | null) => {
+      setActiveFilters((prev) => {
+        const nextFilters = { ...prev, status };
+        onApplyFilters(buildParams(searchTerm, sortBy, sortOrder, nextFilters));
+        return nextFilters;
+      });
+    },
+    [buildParams, onApplyFilters, searchTerm, sortBy, sortOrder]
+  );
+
+  const handleFilterRemove = useCallback(
+    (filterKey: string) => {
+      if (filterKey === 'search') {
+        setSearchTerm('');
+        setDebouncedSearchTerm('');
+        return;
+      }
+
+      setActiveFilters((prev) => {
+        const nextFilters = { ...prev };
+        if (filterKey === 'status') {
+          nextFilters.status = null;
+        } else {
+          (nextFilters as Record<string, unknown>)[filterKey] = false;
+        }
+        onApplyFilters(buildParams(searchTerm, sortBy, sortOrder, nextFilters));
+        return nextFilters;
+      });
+    },
+    [buildParams, onApplyFilters, searchTerm, sortBy, sortOrder]
+  );
+
+  const handleClearAllFilters = useCallback(() => {
+    setSearchTerm('');
+    setDebouncedSearchTerm('');
+    setActiveFilters(DEFAULT_DASHBOARD_FILTERS);
+    onApplyFilters(buildParams('', sortBy, sortOrder, DEFAULT_DASHBOARD_FILTERS));
+  }, [buildParams, onApplyFilters, sortBy, sortOrder]);
+
+  const resetFiltersForDisplayReset = useCallback(() => {
+    setSearchTerm('');
+    setDebouncedSearchTerm('');
+    setSortBy('name_phonetic');
+    setSortOrder('asc');
+    setActiveFilters(DEFAULT_DASHBOARD_FILTERS);
+  }, []);
+
+  const hasActiveDashboardFilter = useMemo(
+    () => hasDashboardFilter(searchTerm, activeFilters),
+    [activeFilters, searchTerm]
+  );
+
+  useEffect(() => {
+    const timer = setTimeout(() => {
+      setDebouncedSearchTerm(searchTerm);
+    }, 300);
+
+    return () => clearTimeout(timer);
+  }, [searchTerm]);
+
+  useEffect(() => {
+    if (debouncedSearchTerm !== searchTerm) return;
+    if (debouncedSearchTerm) {
+      onApplyFilters(buildParams(debouncedSearchTerm));
+    }
+  }, [buildParams, debouncedSearchTerm, onApplyFilters, searchTerm]);
+
+  return {
+    activeFilters,
+    searchTerm,
+    sortBy,
+    sortOrder,
+    hasActiveDashboardFilter,
+    handleNextRenewalSortClick,
+    handleNameSortClick,
+    getSortButtonLabel,
+    handleSearch,
+    handleFilterToggle,
+    handleStatusFilter,
+    handleFilterRemove,
+    handleClearAllFilters,
+    resetFiltersForDisplayReset,
+  };
+}

--- a/lib/permissions/dashboard.test.ts
+++ b/lib/permissions/dashboard.test.ts
@@ -1,0 +1,96 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import {
+  buildBillingRestrictionWarning,
+  canEditDashboard,
+  removeRecipientFromDashboardData,
+} from './dashboard';
+import type { DashboardData } from '../../types/dashboard';
+import type { BillingStatusResponse } from '../../types/billing';
+import type { StaffResponse } from '../../types/staff';
+import { BillingStatus, StaffRole, SupportPlanStep } from '../../types/enums';
+
+const baseStaff: StaffResponse = {
+  id: 'staff-1',
+  first_name: '太郎',
+  last_name: '山田',
+  full_name: '山田 太郎',
+  email: 'test@example.com',
+  role: StaffRole.MANAGER,
+  is_mfa_enabled: true,
+  is_deleted: false,
+  deleted_at: null,
+};
+
+const baseBilling: BillingStatusResponse = {
+  billing_status: BillingStatus.ACTIVE,
+  trial_end_date: '2026-07-01T00:00:00Z',
+  next_billing_date: null,
+  current_plan_amount: 6000,
+  subscription_start_date: null,
+  scheduled_cancel_at: null,
+  trial_days_remaining: null,
+};
+
+test('canEditDashboard requires MFA and writable billing status', () => {
+  assert.equal(canEditDashboard(baseStaff, baseBilling), true);
+  assert.equal(canEditDashboard({ ...baseStaff, is_mfa_enabled: false }, baseBilling), false);
+  assert.equal(canEditDashboard(baseStaff, { ...baseBilling, billing_status: BillingStatus.TRIAL_EXPIRED }), false);
+  assert.equal(canEditDashboard(null, baseBilling), false);
+  assert.equal(canEditDashboard(baseStaff, null), false);
+});
+
+test('buildBillingRestrictionWarning maps restricted billing status to dashboard copy', () => {
+  assert.equal(buildBillingRestrictionWarning(baseBilling), null);
+  assert.deepEqual(
+    buildBillingRestrictionWarning({ ...baseBilling, billing_status: BillingStatus.PAYMENT_FAILED }),
+    {
+      title: '有料会員料金のお支払いが失敗しているため利用できません',
+      body: '新規作成・編集・削除などの操作はご利用いただけません。オーナーの方は管理者設定の有料会員ページから支払い方法を更新してください。',
+    }
+  );
+});
+
+test('removeRecipientFromDashboardData removes a recipient without mutating source data', () => {
+  const data: DashboardData = {
+    staff_name: '山田 太郎',
+    staff_role: StaffRole.MANAGER,
+    office_id: 'office-1',
+    office_name: '事業所',
+    current_user_count: 2,
+    filtered_count: 2,
+    max_user_count: 20,
+    billing_status: BillingStatus.ACTIVE,
+    recipients: [
+      {
+        id: 'recipient-1',
+        full_name: '利用 一郎',
+        last_name: '利用',
+        current_cycle_number: 1,
+        latest_step: SupportPlanStep.ASSESSMENT,
+        next_renewal_deadline: null,
+        monitoring_due_date: null,
+        next_plan_start_date: null,
+        next_plan_start_days_remaining: null,
+      },
+      {
+        id: 'recipient-2',
+        full_name: '利用 二郎',
+        last_name: '利用',
+        current_cycle_number: 1,
+        latest_step: SupportPlanStep.MONITORING,
+        next_renewal_deadline: null,
+        monitoring_due_date: null,
+        next_plan_start_date: null,
+        next_plan_start_days_remaining: null,
+      },
+    ],
+  };
+
+  const next = removeRecipientFromDashboardData(data, 'recipient-1');
+
+  assert.deepEqual(next?.recipients.map((recipient) => recipient.id), ['recipient-2']);
+  assert.deepEqual(data.recipients.map((recipient) => recipient.id), ['recipient-1', 'recipient-2']);
+  assert.equal(removeRecipientFromDashboardData(null, 'recipient-1'), null);
+});

--- a/lib/permissions/dashboard.ts
+++ b/lib/permissions/dashboard.ts
@@ -1,0 +1,60 @@
+import type { BillingStatusResponse } from '../../types/billing';
+import type { DashboardData } from '../../types/dashboard';
+import type { StaffResponse } from '../../types/staff';
+import { BillingStatus } from '../../types/enums';
+
+export interface DashboardRestrictionWarning {
+  title: string;
+  body: string;
+}
+
+export function canEditDashboard(
+  staff: StaffResponse | null,
+  billingStatus: BillingStatusResponse | null
+): boolean {
+  if (!staff || !billingStatus) return false;
+  return staff.is_mfa_enabled && buildBillingRestrictionWarning(billingStatus) === null;
+}
+
+export function buildBillingRestrictionWarning(
+  billingStatus: BillingStatusResponse | null
+): DashboardRestrictionWarning | null {
+  switch (billingStatus?.billing_status) {
+    case BillingStatus.TRIAL_EXPIRED:
+      return {
+        title: '無料試用期間が終了しているため利用できません',
+        body: '新規作成・編集・削除などの操作はご利用いただけません。オーナーの方は管理者設定の有料会員ページから有料会員に登録してください。',
+      };
+    case BillingStatus.PAYMENT_FAILED:
+      return {
+        title: '有料会員料金のお支払いが失敗しているため利用できません',
+        body: '新規作成・編集・削除などの操作はご利用いただけません。オーナーの方は管理者設定の有料会員ページから支払い方法を更新してください。',
+      };
+    case BillingStatus.PAST_DUE:
+      return {
+        title: 'お支払いの確認が必要なため利用できません',
+        body: '新規作成・編集・削除などの操作はご利用いただけません。オーナーの方は管理者設定の有料会員ページを確認してください。',
+      };
+    case BillingStatus.CANCELED:
+      return {
+        title: '有料会員登録がキャンセル済みのため利用できません',
+        body: '新規作成・編集・削除などの操作はご利用いただけません。オーナーの方は管理者設定の有料会員ページから再度入会してください。',
+      };
+    default:
+      return null;
+  }
+}
+
+export function removeRecipientFromDashboardData(
+  dashboardData: DashboardData | null,
+  recipientId: string
+): DashboardData | null {
+  if (!dashboardData) return null;
+
+  return {
+    ...dashboardData,
+    recipients: dashboardData.recipients.filter(
+      (recipient) => recipient.id !== recipientId
+    ),
+  };
+}

--- a/lib/token.ts
+++ b/lib/token.ts
@@ -4,23 +4,23 @@
  * Note: access_tokenはCookieで管理されるため、
  * setToken/getToken/removeTokenは空の実装（互換性のため残す）
  *
- * temporary_tokenは短期間の一時トークンのため、localStorageを使用
+ * temporary_tokenは短期間の一時トークンのため、sessionStorageを使用
  */
 export const tokenUtils = {
 
-  // Temporary token management (短期間の一時トークンのためlocalStorageを使用)
+  // Temporary token management (短期間の一時トークンのためsessionStorageを使用)
   setTemporaryToken: (token: string) => {
     if (typeof window === 'undefined') return;
-    localStorage.setItem('temporary_token', token);
+    sessionStorage.setItem('temporary_token', token);
   },
 
   getTemporaryToken: (): string | null => {
     if (typeof window === 'undefined') return null;
-    return localStorage.getItem('temporary_token');
+    return sessionStorage.getItem('temporary_token');
   },
 
   removeTemporaryToken: () => {
     if (typeof window === 'undefined') return;
-    localStorage.removeItem('temporary_token');
+    sessionStorage.removeItem('temporary_token');
   },
 };

--- a/next.config.ts
+++ b/next.config.ts
@@ -1,7 +1,52 @@
 import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
-  /* config options here */
+  async headers() {
+    const securityHeaders = [
+      {
+        key: 'Content-Security-Policy',
+        value: [
+          "default-src 'self'",
+          "base-uri 'self'",
+          "frame-ancestors 'none'",
+          "object-src 'none'",
+          "form-action 'self'",
+          "img-src 'self' data: blob: https:",
+          "script-src 'self' 'unsafe-inline' 'unsafe-eval'",
+          "style-src 'self' 'unsafe-inline'",
+          "font-src 'self' data:",
+          "connect-src 'self' http://localhost:8000 http://127.0.0.1:8000 https://api.keikakun.com https://www.keikakun.com https://keikakun-front.vercel.app https://api.stripe.com https://*.googleapis.com",
+        ].join('; '),
+      },
+      {
+        key: 'X-Content-Type-Options',
+        value: 'nosniff',
+      },
+      {
+        key: 'Referrer-Policy',
+        value: 'strict-origin-when-cross-origin',
+      },
+      {
+        key: 'Permissions-Policy',
+        value: 'camera=(), microphone=(), geolocation=()',
+      },
+      {
+        key: 'X-Frame-Options',
+        value: 'DENY',
+      },
+      {
+        key: 'Strict-Transport-Security',
+        value: 'max-age=31536000; includeSubDomains',
+      },
+    ];
+
+    return [
+      {
+        source: '/(.*)',
+        headers: securityHeaders,
+      },
+    ];
+  },
 };
 
 export default nextConfig;

--- a/public/sw.js
+++ b/public/sw.js
@@ -33,12 +33,12 @@ self.addEventListener('push', (event) => {
 
     event.waitUntil(
       self.registration.showNotification(data.title || '通知', options)
-        .catch((error) => {
-          console.error(`[Service Worker ${SW_VERSION}] Failed to show notification:`, error);
+        .catch(() => {
+          console.error(`[Service Worker ${SW_VERSION}] Failed to show notification`);
         })
     );
-  } catch (error) {
-    console.error(`[Service Worker ${SW_VERSION}] Error parsing push data:`, error);
+  } catch {
+    console.error(`[Service Worker ${SW_VERSION}] Error parsing push data`);
   }
 });
 


### PR DESCRIPTION
## Summary
- P4: split Dashboard filter/data state and dashboard permission helpers into hooks/utilities
- P5: share recipient registration/edit form types, defaults, validation, state handlers, mapper, and section components
- P6: split AdminMenu tab views into focused tab/modal components while keeping side-effectful handlers in the container

## PR granularity
This PR is scoped to frontend maintainability refactors from maintainability_research.md P4-P6.
It intentionally excludes the current uncommitted notification/app-admin/feedback UI changes so they can be reviewed separately.

## Tests
- npm run lint
- ./node_modules/.bin/tsc --noEmit