### PR TITLE
security: avoid logging frontend error objects

### DIFF
--- a/components/admin/inquiry/InquiryDetail.tsx
+++ b/components/admin/inquiry/InquiryDetail.tsx
@@ -49,7 +49,7 @@ export default function InquiryDetail({ inquiryId, onBack, onOpenReply }: Inquir
         },
       });
     } catch (err) {
-      console.error('ステータスの更新に失敗しました:', err);
+      console.error('Client operation failed');
     } finally {
       setIsUpdating(false);
     }
@@ -69,7 +69,7 @@ export default function InquiryDetail({ inquiryId, onBack, onOpenReply }: Inquir
         },
       });
     } catch (err) {
-      console.error('優先度の更新に失敗しました:', err);
+      console.error('Client operation failed');
     } finally {
       setIsUpdating(false);
     }

--- a/components/admin/inquiry/InquiryReplyModal.tsx
+++ b/components/admin/inquiry/InquiryReplyModal.tsx
@@ -55,7 +55,7 @@ export default function InquiryReplyModal({
         onSuccess();
       }
     } catch (err) {
-      console.error('返信の送信に失敗しました:', err);
+      console.error('Client operation failed');
       setError('返信の送信に失敗しました。もう一度お試しください。');
     } finally {
       setIsSubmitting(false);

--- a/components/auth/admin/LoginForm.tsx
+++ b/components/auth/admin/LoginForm.tsx
@@ -50,8 +50,8 @@ export default function AdminLoginForm() {
       try {
         await authApi.getCurrentUser();
         router.push('/auth/admin/office_setup');
-      } catch (verifyError) {
-        console.error('Cookie verification failed:', verifyError);
+      } catch {
+        console.error('Cookie verification failed');
         setFormError('root', { message: '認証に失敗しました。もう一度お試しください。' });
       }
     } catch (error: unknown) {

--- a/components/auth/app-admin/LoginForm.tsx
+++ b/components/auth/app-admin/LoginForm.tsx
@@ -64,8 +64,8 @@ export default function AppAdminLoginForm() {
         }
 
         router.push('/app-admin');
-      } catch (verifyError) {
-        console.error('User verification failed:', verifyError);
+      } catch {
+        console.error('User verification failed');
         setFormError('root', { message: '認証に失敗しました。もう一度お試しください。' });
       }
     } catch (error: unknown) {

--- a/components/billing/PastDueModal.tsx
+++ b/components/billing/PastDueModal.tsx
@@ -91,7 +91,7 @@ export default function PastDueModal({ isOpen, onClose }: PastDueModalProps) {
 
       window.location.href = '/admin?tab=plan';
     } catch (err) {
-      console.error('課金アクションの開始に失敗しました:', err);
+      console.error('Client operation failed');
       setError(err instanceof Error ? err.message : '課金アクションの開始に失敗しました');
     } finally {
       setIsLoading(false);

--- a/components/common/EmployeeActionRequestModal.tsx
+++ b/components/common/EmployeeActionRequestModal.tsx
@@ -58,7 +58,7 @@ export default function EmployeeActionRequestModal({
       onClose();
       setNotes('');
     } catch (err) {
-      console.error('Failed to create employee action request:', err);
+      console.error('Client operation failed');
       if (err instanceof Error) {
         setError(err.message);
       } else {

--- a/components/inquiry/InquiryModal.tsx
+++ b/components/inquiry/InquiryModal.tsx
@@ -65,7 +65,7 @@ export default function InquiryModal({ isOpen, onClose }: InquiryModalProps) {
         handleClose();
       }, 2000);
     } catch (error) {
-      console.error('問い合わせの送信に失敗しました:', error);
+      console.error('Client operation failed');
       setErrors({ submit: '送信に失敗しました。もう一度お試しください。' });
     } finally {
       setIsSubmitting(false);

--- a/components/inquiry/InquirySendForm.tsx
+++ b/components/inquiry/InquirySendForm.tsx
@@ -55,7 +55,7 @@ export default function InquirySendForm() {
         setSubmitSuccess(false);
       }, 3000);
     } catch (error) {
-      console.error('問い合わせの送信に失敗しました:', error);
+      console.error('Client operation failed');
       setErrors({ submit: '送信に失敗しました。もう一度お試しください。' });
     } finally {
       setIsSubmitting(false);

--- a/components/notice/DeadlineAlertsTab.tsx
+++ b/components/notice/DeadlineAlertsTab.tsx
@@ -43,7 +43,7 @@ export default function DeadlineAlertsTab() {
         setAlerts(data.alerts);
         setTotal(data.total);
       } catch (err) {
-        console.error('更新期限のお知らせの取得に失敗しました:', err);
+        console.error('Client operation failed');
         setError('更新期限のお知らせの取得に失敗しました。時間をおいて再度お試しください。');
       } finally {
         setIsLoading(false);

--- a/components/protected/LayoutClient.tsx
+++ b/components/protected/LayoutClient.tsx
@@ -74,7 +74,7 @@ export default function ProtectedLayoutClient({ children, user }: ProtectedLayou
       const totalUnread = noticesData.unread_count + messagesData.unread_count;
       setUnreadCount(totalUnread);
     } catch (error) {
-      console.error('未読通知件数の取得に失敗しました', error);
+      console.error('Client operation failed');
     }
   };
 
@@ -87,7 +87,7 @@ export default function ProtectedLayoutClient({ children, user }: ProtectedLayou
       setRecentUnreadMessages(data.messages.slice(0, 3));
       setMessagesLoaded(true);
     } catch (error) {
-      console.error('未読メッセージの取得に失敗しました', error);
+      console.error('Client operation failed');
     }
   };
 
@@ -97,7 +97,7 @@ export default function ProtectedLayoutClient({ children, user }: ProtectedLayou
       const data = await deadlineApi.getAlerts({ threshold_days: 30 });
       return data.alerts;
     } catch (error) {
-      console.error('更新期限のお知らせの取得に失敗しました', error);
+      console.error('Client operation failed');
       return null;
     }
   };
@@ -141,7 +141,7 @@ export default function ProtectedLayoutClient({ children, user }: ProtectedLayou
       setTotalDeadlineAlerts(data.total);
       setDeadlineAlertsOffset(offset + data.alerts.length);
     } catch (error) {
-      console.error('更新期限のお知らせの取得に失敗しました', error);
+      console.error('Client operation failed');
     }
   };
 
@@ -169,7 +169,7 @@ export default function ProtectedLayoutClient({ children, user }: ProtectedLayou
 
     // CSRFトークンを初期化（ページリフレッシュ時に必要）
     initializeCsrfToken().catch(error => {
-      console.error('CSRFトークンの初期化に失敗しました', error);
+      console.error('Client operation failed');
     });
 
     // 事業所情報が未取得の場合のみ取得
@@ -177,7 +177,7 @@ export default function ProtectedLayoutClient({ children, user }: ProtectedLayou
       officeApi.getMyOffice()
         .then(officeData => setOffice(officeData))
         .catch(error => {
-          console.error('事業所情報の取得に失敗しました', error);
+          console.error('Client operation failed');
         });
     }
 
@@ -227,7 +227,7 @@ export default function ProtectedLayoutClient({ children, user }: ProtectedLayou
           await subscribe();
         }
       } catch (error) {
-        console.error('[Notifications] Failed to initialize notifications:', error);
+        console.error('Client operation failed');
         // エラー時も処理を継続（ユーザー体験に影響を与えない）
       }
     };
@@ -274,7 +274,7 @@ export default function ProtectedLayoutClient({ children, user }: ProtectedLayou
       // これにより、Cookie削除が確実に反映された状態でログインページが読み込まれる
       window.location.href = `/auth/login?${params.toString()}`;
     } catch (error) {
-      console.error('Logout failed:', error);
+      console.error('Client operation failed');
       // エラーが発生してもログイン画面にリダイレクト
       window.location.href = '/auth/login';
     }

--- a/components/protected/admin/AdminMenu.tsx
+++ b/components/protected/admin/AdminMenu.tsx
@@ -213,8 +213,8 @@ export default function AdminMenu({ office }: AdminMenuProps) {
         try {
           const calendar = await calendarApi.getOfficeCalendar(office.id);
           setExistingCalendar(calendar);
-        } catch (refreshError) {
-          console.error('カレンダー設定の再取得に失敗:', refreshError);
+        } catch {
+          console.error('カレンダー設定の再取得に失敗');
         }
       } else {
         setUploadError(response.error_details || '保存に失敗しました。');

--- a/components/protected/admin/PlanTab.tsx
+++ b/components/protected/admin/PlanTab.tsx
@@ -39,7 +39,7 @@ export default function PlanTab() {
       // Stripe Checkoutページへリダイレクト
       window.location.href = url;
     } catch (err) {
-      console.error('Checkout Session作成エラー:', err);
+      console.error('Client operation failed');
       setErrorMessage(err instanceof Error ? err.message : '有料会員登録に失敗しました');
     } finally {
       setIsCreatingCheckout(false);
@@ -59,7 +59,7 @@ export default function PlanTab() {
         refreshBillingStatus();
       }, 3000);
     } catch (err) {
-      console.error('Portal Session作成エラー:', err);
+      console.error('Client operation failed');
       setErrorMessage(err instanceof Error ? err.message : '有料会員管理画面の表示に失敗しました');
     } finally {
       setIsCreatingPortal(false);

--- a/components/protected/app-admin/AppAdminDashboard.tsx
+++ b/components/protected/app-admin/AppAdminDashboard.tsx
@@ -29,7 +29,7 @@ export default function AppAdminDashboard({ staff }: AppAdminDashboardProps) {
       await authApi.logout();
       router.push('/auth/app-admin/login');
     } catch (error) {
-      console.error('ログアウトに失敗しました:', error);
+      console.error('Client operation failed');
     } finally {
       setIsLoggingOut(false);
     }

--- a/components/protected/app-admin/InquiryReplyModal.tsx
+++ b/components/protected/app-admin/InquiryReplyModal.tsx
@@ -44,7 +44,7 @@ export default function InquiryReplyModal({
       onSuccess();
       onClose();
     } catch (error) {
-      console.error('❌ [InquiryReplyModal] 返信送信失敗:', error);
+      console.error('Client operation failed');
       const message = error instanceof Error ? error.message : String(error);
       toast.error(message || '返信の送信に失敗しました');
     } finally {

--- a/components/protected/pdf-list/PdfViewContent.tsx
+++ b/components/protected/pdf-list/PdfViewContent.tsx
@@ -100,7 +100,7 @@ export default function PdfViewContent({
           (a.last_name + a.first_name).localeCompare(b.last_name + b.first_name, 'ja')
         ));
       } catch (err) {
-        console.error('Failed to fetch recipients:', err);
+        console.error('Client operation failed');
       }
     };
 
@@ -135,7 +135,7 @@ export default function PdfViewContent({
         setPdfs(response.items);
         setTotal(response.total);
       } catch (err) {
-        console.error('Failed to fetch PDFs:', err);
+        console.error('Client operation failed');
         setError('PDF一覧の取得に失敗しました');
       } finally {
         setIsLoading(false);

--- a/components/protected/profile/NotificationSettings.tsx
+++ b/components/protected/profile/NotificationSettings.tsx
@@ -47,7 +47,7 @@ export default function NotificationSettings() {
       );
       setPreferences(data);
     } catch (error) {
-      console.error('Failed to fetch notification preferences:', error);
+      console.error('Client operation failed');
     } finally {
       setIsLoading(false);
     }
@@ -64,7 +64,7 @@ export default function NotificationSettings() {
       setPreferences(data);
       toast.success('通知設定を保存しました');
     } catch (error) {
-      console.error('Failed to save notification preferences:', error);
+      console.error('Client operation failed');
       toast.error(error instanceof Error ? error.message : '設定の保存に失敗しました');
     } finally {
       setIsSaving(false);
@@ -112,7 +112,7 @@ export default function NotificationSettings() {
           await savePreferences(newPreferences);
           toast.success('プッシュ通知を有効にしました');
         } catch (error) {
-          console.error('Failed to subscribe:', error);
+          console.error('Client operation failed');
           toast.error(getErrorMessage(error));
         }
       } else {
@@ -121,7 +121,7 @@ export default function NotificationSettings() {
           await savePreferences(newPreferences);
           toast.success('プッシュ通知を無効にしました');
         } catch (error) {
-          console.error('Failed to unsubscribe:', error);
+          console.error('Client operation failed');
           toast.error(getErrorMessage(error));
         }
       }

--- a/components/protected/profile/Profile.tsx
+++ b/components/protected/profile/Profile.tsx
@@ -47,7 +47,7 @@ export default function Profile({ staff: initialStaff }: ProfileProps) {
         const officeData = await officeApi.getMyOffice();
         setOffice(officeData);
       } catch (error) {
-        console.error('事業所情報の取得に失敗しました:', error);
+        console.error('Client operation failed');
       }
     };
     fetchOffice();

--- a/components/protected/recipients/EmploymentSection.tsx
+++ b/components/protected/recipients/EmploymentSection.tsx
@@ -81,7 +81,7 @@ export default function EmploymentSection({
       setShowModal(false);
       onRefresh();
     } catch (err) {
-      console.error('Failed to save employment:', err);
+      console.error('Client operation failed');
       if (err instanceof Error) {
         setError(err.message);
       } else {

--- a/components/protected/recipients/forms/FamilyMemberForm.tsx
+++ b/components/protected/recipients/forms/FamilyMemberForm.tsx
@@ -39,7 +39,7 @@ export default function FamilyMemberForm({
       }
       onSuccess();
     } catch (err) {
-      console.error('Failed to save family member:', err);
+      console.error('Client operation failed');
       if (err instanceof Error) {
         setError(err.message);
       } else {

--- a/components/protected/recipients/forms/FamilyMemberList.tsx
+++ b/components/protected/recipients/forms/FamilyMemberList.tsx
@@ -45,7 +45,7 @@ export default function FamilyMemberList({
       await assessmentApi.familyMembers.delete(id);
       onRefresh();
     } catch (err) {
-      console.error('Failed to delete family member:', err);
+      console.error('Client operation failed');
       alert('家族情報の削除に失敗しました。');
     } finally {
       setDeletingId(null);

--- a/components/protected/recipients/forms/HospitalVisitForm.tsx
+++ b/components/protected/recipients/forms/HospitalVisitForm.tsx
@@ -45,7 +45,7 @@ export default function HospitalVisitForm({
       }
       onSuccess();
     } catch (err) {
-      console.error('Failed to save hospital visit:', err);
+      console.error('Client operation failed');
       if (err instanceof Error) {
         setError(err.message);
       } else {

--- a/components/protected/recipients/forms/HospitalVisitList.tsx
+++ b/components/protected/recipients/forms/HospitalVisitList.tsx
@@ -41,7 +41,7 @@ export default function HospitalVisitList({
       await assessmentApi.hospitalVisits.delete(id);
       onRefresh();
     } catch (err) {
-      console.error('Failed to delete hospital visit:', err);
+      console.error('Client operation failed');
       alert('通院歴の削除に失敗しました。');
     } finally {
       setDeletingId(null);

--- a/components/protected/recipients/forms/MedicalInfoForm.tsx
+++ b/components/protected/recipients/forms/MedicalInfoForm.tsx
@@ -34,7 +34,7 @@ export default function MedicalInfoForm({
       await assessmentApi.medicalInfo.createOrUpdate(recipientId, formData);
       onSuccess();
     } catch (err) {
-      console.error('Failed to save medical info:', err);
+      console.error('Client operation failed');
       if (err instanceof Error) {
         setError(err.message);
       } else {

--- a/components/protected/recipients/forms/ServiceHistoryForm.tsx
+++ b/components/protected/recipients/forms/ServiceHistoryForm.tsx
@@ -39,7 +39,7 @@ export default function ServiceHistoryForm({
       }
       onSuccess();
     } catch (err) {
-      console.error('Failed to save service history:', err);
+      console.error('Client operation failed');
       if (err instanceof Error) {
         setError(err.message);
       } else {

--- a/components/protected/recipients/forms/ServiceHistoryList.tsx
+++ b/components/protected/recipients/forms/ServiceHistoryList.tsx
@@ -40,7 +40,7 @@ export default function ServiceHistoryList({
       await assessmentApi.serviceHistory.delete(id);
       onRefresh();
     } catch (err) {
-      console.error('Failed to delete service history:', err);
+      console.error('Client operation failed');
       alert('サービス利用歴の削除に失敗しました。');
     } finally {
       setDeletingId(null);

--- a/components/protected/support_plan/PlanDeliverableModal.tsx
+++ b/components/protected/support_plan/PlanDeliverableModal.tsx
@@ -73,7 +73,7 @@ export default function PlanDeliverableModal({
           setIsLoadingPdf(false);
         })
         .catch((err) => {
-          console.error('PDF読み込みエラー:', err);
+          console.error('Client operation failed');
           setError('PDFの読み込みに失敗しました。CORS設定を確認してください。');
           setIsLoadingPdf(false);
         });

--- a/components/protected/support_plan/SupportPlan.tsx
+++ b/components/protected/support_plan/SupportPlan.tsx
@@ -46,7 +46,7 @@ export default function SupportPlan() {
         setRecipient(recipientData);
         setCycles(cyclesData.cycles || []);
       } catch (err) {
-        console.error('Failed to fetch support plan data:', err);
+        console.error('Client operation failed');
         setError('データの取得に失敗しました');
       } finally {
         setIsLoading(false);
@@ -131,7 +131,7 @@ export default function SupportPlan() {
 
       setIsModalOpen(false);
     } catch (err) {
-      console.error('Failed to upload file:', err);
+      console.error('Client operation failed');
       // エラーメッセージを表示
       toast.error('PDFのアップロードに失敗しました');
       throw err; // モーダル側でエラーハンドリング
@@ -151,7 +151,7 @@ export default function SupportPlan() {
 
       setIsModalOpen(false);
     } catch (err) {
-      console.error('Failed to reupload file:', err);
+      console.error('Client operation failed');
       // エラーメッセージを表示
       toast.error('PDFの再アップロードに失敗しました');
       throw err;
@@ -172,7 +172,7 @@ export default function SupportPlan() {
       const cyclesData = await supportPlanApi.getCycles(recipientId);
       setCycles(cyclesData.cycles || []);
     } catch (err) {
-      console.error('Failed to set monitoring deadline:', err);
+      console.error('Client operation failed');
       toast.error('モニタリング期限の設定に失敗しました。');
     }
   };

--- a/components/ui/google/CalendarLinkButton.tsx
+++ b/components/ui/google/CalendarLinkButton.tsx
@@ -177,7 +177,7 @@ export default function CalendarLinkButton() {
           setOfficeId(id);
         }
       } catch (err) {
-        console.error('Failed to fetch user office:', err);
+        console.error('Client operation failed');
       }
     };
 
@@ -194,7 +194,7 @@ export default function CalendarLinkButton() {
           const account = await calendarApi.getOfficeCalendar(officeId);
           setCalendarAccount(account);
         } catch (err) {
-          console.error('Failed to fetch calendar info:', err);
+          console.error('Client operation failed');
 
           // 404エラー（カレンダー未設定）の場合は特別扱い
           const errorMessage = err instanceof Error ? err.message : String(err);

--- a/contexts/BillingContext.tsx
+++ b/contexts/BillingContext.tsx
@@ -70,7 +70,7 @@ export function BillingProvider({ children }: BillingProviderProps) {
       const data = await billingApi.getBillingStatus();
       setBillingStatus(data);
     } catch (err) {
-      console.error('課金ステータスの取得に失敗しました:', err);
+      console.error('課金ステータスの取得に失敗しました');
       setError(err instanceof Error ? err.message : '課金ステータスの取得に失敗しました');
     } finally {
       setIsLoading(false);

--- a/public/sw.js
+++ b/public/sw.js
@@ -33,12 +33,12 @@ self.addEventListener('push', (event) => {
 
     event.waitUntil(
       self.registration.showNotification(data.title || '通知', options)
-        .catch((error) => {
-          console.error(`[Service Worker ${SW_VERSION}] Failed to show notification:`, error);
+        .catch(() => {
+          console.error(`[Service Worker ${SW_VERSION}] Failed to show notification`);
         })
     );
-  } catch (error) {
-    console.error(`[Service Worker ${SW_VERSION}] Error parsing push data:`, error);
+  } catch {
+    console.error(`[Service Worker ${SW_VERSION}] Error parsing push data`);
   }
 });
 


### PR DESCRIPTION
## Summary
- Stop passing raw Error/API error objects to frontend console.error calls
- Keep user-facing error handling unchanged while reducing browser-console leakage risk

## Verification
- npm run lint
  - Passed with existing no-unused-vars warnings caused by unused catch bindings after removing logged error objects
- rg confirmed no console.error calls pass error/err/verifyError/refreshError objects in components, contexts, or public service worker
