### PR TITLE
[codex] fix frontend CSRF handling and admin UI

### DIFF
--- a/app/(protected)/notice/page.tsx
+++ b/app/(protected)/notice/page.tsx
@@ -5,15 +5,21 @@ import ApprovalRequestsTab from '@/components/notice/ApprovalRequestsTab';
 import DeadlineAlertsTab from '@/components/notice/DeadlineAlertsTab';
 import MessagesTab from '@/components/notice/MessagesTab';
 import MessageSendForm from '@/components/messages/MessageSendForm';
+import FeedbackForm from '@/components/protected/profile/FeedbackForm';
 
-type TabType = 'messages' | 'approvals' | 'deadlines' | 'send';
-type CategoryType = 'recipients' | 'messages';
+type TabType = 'messages' | 'approvals' | 'deadlines' | 'send' | 'feedback';
+type CategoryType = 'recipients' | 'messages' | 'feedback';
 
 export default function NoticePage() {
   const [activeTab, setActiveTab] = useState<TabType>('deadlines');
   const [isReceiveMenuOpen, setIsReceiveMenuOpen] = useState(false);
   const isReceiveActive = activeTab === 'messages' || activeTab === 'approvals';
-  const activeCategory: CategoryType = activeTab === 'deadlines' ? 'recipients' : 'messages';
+  let activeCategory: CategoryType = 'messages';
+  if (activeTab === 'deadlines') {
+    activeCategory = 'recipients';
+  } else if (activeTab === 'feedback') {
+    activeCategory = 'feedback';
+  }
 
   const handleSelectReceiveTab = (tab: Extract<TabType, 'messages' | 'approvals'>) => {
     setActiveTab(tab);
@@ -50,97 +56,117 @@ export default function NoticePage() {
         >
           個別メッセージ/お知らせ
         </button>
+        <button
+          onClick={() => {
+            setActiveTab('feedback');
+            setIsReceiveMenuOpen(false);
+          }}
+          className={`px-7 py-4 text-lg font-bold transition-all ${
+            activeCategory === 'feedback'
+              ? 'text-slate-950 border-b-2 border-blue-500 bg-blue-50 dark:text-white dark:bg-blue-900/20'
+              : 'text-slate-600 hover:text-slate-950 hover:bg-slate-100 dark:text-gray-400 dark:hover:text-gray-200 dark:hover:bg-gray-800/30'
+          }`}
+        >
+          不具合/ご要望
+        </button>
       </div>
 
       {/* 個別タブナビゲーション */}
-      <div className="mb-6 flex gap-2 border-b border-slate-200 bg-slate-50 dark:border-gray-700 dark:bg-gray-900/40">
-        {activeCategory === 'recipients' && (
-          <button
-            onClick={() => {
-              setActiveTab('deadlines');
-              setIsReceiveMenuOpen(false);
-            }}
-            className={`px-6 py-3 text-base font-bold transition-all ${
-              activeTab === 'deadlines'
-                ? 'text-slate-950 border-b-2 border-blue-500 bg-white dark:text-white dark:bg-gray-800'
-                : 'text-slate-600 hover:text-slate-950 hover:bg-white dark:text-gray-400 dark:hover:text-gray-200 dark:hover:bg-gray-800/70'
-            }`}
-          >
-            更新期限の近い利用者
-          </button>
-        )}
-
-        {activeCategory === 'messages' && (
-          <>
-            <div className="relative">
-              <button
-                onClick={() => setIsReceiveMenuOpen((open) => !open)}
-                className={`px-6 py-3 text-base font-bold transition-all flex items-center gap-2 ${
-                  isReceiveActive
-                    ? 'text-slate-950 border-b-2 border-blue-500 bg-white dark:text-white dark:bg-gray-800'
-                    : 'text-slate-600 hover:text-slate-950 hover:bg-white dark:text-gray-400 dark:hover:text-gray-200 dark:hover:bg-gray-800/70'
-                }`}
-                aria-expanded={isReceiveMenuOpen}
-                aria-haspopup="menu"
-              >
-                📥 受信
-                <span className="text-sm" aria-hidden="true">
-                  {isReceiveMenuOpen ? '▲' : '▼'}
-                </span>
-              </button>
-
-              {isReceiveMenuOpen && (
-                <div
-                  className="absolute left-0 top-full z-20 mt-2 min-w-56 overflow-hidden rounded-lg border border-slate-300 bg-white shadow-lg dark:border-gray-700 dark:bg-gray-900"
-                  role="menu"
-                >
-                  <button
-                    onClick={() => handleSelectReceiveTab('messages')}
-                    className={`block w-full px-5 py-4 text-left text-lg font-bold transition-colors ${
-                      activeTab === 'messages'
-                        ? 'bg-blue-50 text-blue-700 dark:bg-blue-900/30 dark:text-blue-300'
-                        : 'text-slate-700 hover:bg-slate-100 dark:text-gray-300 dark:hover:bg-gray-800'
-                    }`}
-                    role="menuitem"
-                  >
-                    メッセージ
-                  </button>
-                  <button
-                    onClick={() => handleSelectReceiveTab('approvals')}
-                    className={`block w-full px-5 py-4 text-left text-lg font-bold transition-colors ${
-                      activeTab === 'approvals'
-                        ? 'bg-blue-50 text-blue-700 dark:bg-blue-900/30 dark:text-blue-300'
-                        : 'text-slate-700 hover:bg-slate-100 dark:text-gray-300 dark:hover:bg-gray-800'
-                    }`}
-                    role="menuitem"
-                  >
-                    承認リクエスト
-                  </button>
-                </div>
-              )}
-            </div>
+      {activeCategory !== 'feedback' && (
+        <div className="mb-6 flex gap-2 border-b border-slate-200 bg-slate-50 dark:border-gray-700 dark:bg-gray-900/40">
+          {activeCategory === 'recipients' && (
             <button
               onClick={() => {
-                setActiveTab('send');
+                setActiveTab('deadlines');
                 setIsReceiveMenuOpen(false);
               }}
               className={`px-6 py-3 text-base font-bold transition-all ${
-                activeTab === 'send'
+                activeTab === 'deadlines'
                   ? 'text-slate-950 border-b-2 border-blue-500 bg-white dark:text-white dark:bg-gray-800'
                   : 'text-slate-600 hover:text-slate-950 hover:bg-white dark:text-gray-400 dark:hover:text-gray-200 dark:hover:bg-gray-800/70'
               }`}
             >
-              📤 送信
+              更新期限の近い利用者
             </button>
-          </>
-        )}
-      </div>
+          )}
+
+          {activeCategory === 'messages' && (
+            <>
+              <div className="relative">
+                <button
+                  onClick={() => setIsReceiveMenuOpen((open) => !open)}
+                  className={`px-6 py-3 text-base font-bold transition-all flex items-center gap-2 ${
+                    isReceiveActive
+                      ? 'text-slate-950 border-b-2 border-blue-500 bg-white dark:text-white dark:bg-gray-800'
+                      : 'text-slate-600 hover:text-slate-950 hover:bg-white dark:text-gray-400 dark:hover:text-gray-200 dark:hover:bg-gray-800/70'
+                  }`}
+                  aria-expanded={isReceiveMenuOpen}
+                  aria-haspopup="menu"
+                >
+                  📥 受信
+                  <span className="text-sm" aria-hidden="true">
+                    {isReceiveMenuOpen ? '▲' : '▼'}
+                  </span>
+                </button>
+
+                {isReceiveMenuOpen && (
+                  <div
+                    className="absolute left-0 top-full z-20 mt-2 min-w-56 overflow-hidden rounded-lg border border-slate-300 bg-white shadow-lg dark:border-gray-700 dark:bg-gray-900"
+                    role="menu"
+                  >
+                    <button
+                      onClick={() => handleSelectReceiveTab('messages')}
+                      className={`block w-full px-5 py-4 text-left text-lg font-bold transition-colors ${
+                        activeTab === 'messages'
+                          ? 'bg-blue-50 text-blue-700 dark:bg-blue-900/30 dark:text-blue-300'
+                          : 'text-slate-700 hover:bg-slate-100 dark:text-gray-300 dark:hover:bg-gray-800'
+                      }`}
+                      role="menuitem"
+                    >
+                      メッセージ
+                    </button>
+                    <button
+                      onClick={() => handleSelectReceiveTab('approvals')}
+                      className={`block w-full px-5 py-4 text-left text-lg font-bold transition-colors ${
+                        activeTab === 'approvals'
+                          ? 'bg-blue-50 text-blue-700 dark:bg-blue-900/30 dark:text-blue-300'
+                          : 'text-slate-700 hover:bg-slate-100 dark:text-gray-300 dark:hover:bg-gray-800'
+                      }`}
+                      role="menuitem"
+                    >
+                      承認リクエスト
+                    </button>
+                  </div>
+                )}
+              </div>
+              <button
+                onClick={() => {
+                  setActiveTab('send');
+                  setIsReceiveMenuOpen(false);
+                }}
+                className={`px-6 py-3 text-base font-bold transition-all ${
+                  activeTab === 'send'
+                    ? 'text-slate-950 border-b-2 border-blue-500 bg-white dark:text-white dark:bg-gray-800'
+                    : 'text-slate-600 hover:text-slate-950 hover:bg-white dark:text-gray-400 dark:hover:text-gray-200 dark:hover:bg-gray-800/70'
+                }`}
+              >
+                📤 送信
+              </button>
+            </>
+          )}
+        </div>
+      )}
 
       {/* タブコンテンツ */}
       {activeTab === 'messages' && <MessagesTab />}
       {activeTab === 'approvals' && <ApprovalRequestsTab />}
       {activeTab === 'deadlines' && <DeadlineAlertsTab />}
       {activeTab === 'send' && <MessageSendForm />}
+      {activeTab === 'feedback' && (
+        <div className="pt-6">
+          <FeedbackForm />
+        </div>
+      )}
     </div>
   );
 }

--- a/components/admin/inquiry/InquiryDetail.tsx
+++ b/components/admin/inquiry/InquiryDetail.tsx
@@ -8,7 +8,7 @@ import { FaArrowLeft, FaReply, FaUser, FaEnvelope, FaGlobe, FaDesktop } from 're
 interface InquiryDetailProps {
   inquiryId: string;
   onBack: () => void;
-  onOpenReply: (inquiryId: string) => void;
+  onOpenReply: (inquiry: InquiryFullResponse) => void;
 }
 
 export default function InquiryDetail({ inquiryId, onBack, onOpenReply }: InquiryDetailProps) {
@@ -173,7 +173,7 @@ export default function InquiryDetail({ inquiryId, onBack, onOpenReply }: Inquir
           <div className="bg-white dark:bg-gray-800 rounded-lg border border-slate-300 dark:border-gray-700 p-6">
             <h3 className="text-lg font-semibold text-slate-900 dark:text-white mb-4">アクション</h3>
             <button
-              onClick={() => onOpenReply(inquiryId)}
+              onClick={() => onOpenReply(inquiry)}
               className="w-full flex items-center justify-center gap-2 bg-purple-600 hover:bg-purple-700 text-white px-4 py-2 rounded-lg transition-colors mb-3"
             >
               <FaReply />

--- a/components/protected/LayoutClient.tsx
+++ b/components/protected/LayoutClient.tsx
@@ -17,6 +17,7 @@ import { OfficeResponse } from '@/types/office';
 import { getOfficeTypeLabel } from '@/lib/office-utils';
 import { toast } from 'sonner';
 import { FaHome, FaBars, FaTimes } from 'react-icons/fa';
+import { MdKeyboardArrowDown, MdWarning } from 'react-icons/md';
 import { usePushNotification } from '@/hooks/usePushNotification';
 import { http } from '@/lib/http';
 import { ThemeToggle } from '@/components/theme/ThemeToggle';
@@ -46,9 +47,11 @@ export default function ProtectedLayoutClient({ children, user }: ProtectedLayou
   const pathname = usePathname();
   const [office, setOffice] = useState<OfficeResponse | null>(null);
   const [unreadCount, setUnreadCount] = useState<number>(0);
-  const [isNoticeHovered, setIsNoticeHovered] = useState<boolean>(false);
+  const [isNoticePopoverOpen, setIsNoticePopoverOpen] = useState<boolean>(false);
   const [recentUnreadMessages, setRecentUnreadMessages] = useState<MessageInboxItem[]>([]);
-  const [noticePopoverView, setNoticePopoverView] = useState<'deadlines' | 'messages'>('deadlines');
+  const [isDeadlinePanelOpen, setIsDeadlinePanelOpen] = useState<boolean>(false);
+  const [isDeadlineDrawerOpen, setIsDeadlineDrawerOpen] = useState<boolean>(false);
+  const [showDeadlineDrawerHint, setShowDeadlineDrawerHint] = useState<boolean>(false);
   const [messagesLoaded, setMessagesLoaded] = useState<boolean>(false);
   const [isMounted, setIsMounted] = useState<boolean>(false);
   const [deadlineAlerts, setDeadlineAlerts] = useState<DeadlineAlert[]>([]);
@@ -57,8 +60,10 @@ export default function ProtectedLayoutClient({ children, user }: ProtectedLayou
   const [deadlineAlertsOffset, setDeadlineAlertsOffset] = useState<number>(0);
   const [isMenuOpen, setIsMenuOpen] = useState<boolean>(false);
   const [showOfficeTooltip, setShowOfficeTooltip] = useState<boolean>(false);
+  const noticePopoverRef = useRef<HTMLDivElement | null>(null);
   const longPressTimerRef = useRef<NodeJS.Timeout | null>(null);
   const deadlineAlertsShownRef = useRef<boolean>(false);
+  const deadlineDrawerHintShownRef = useRef<boolean>(false);
   const deadlineAlertsSessionKey = 'keikakun_deadline_alerts_toast_shown';
 
   // Push通知の自動購読機能
@@ -73,8 +78,7 @@ export default function ProtectedLayoutClient({ children, user }: ProtectedLayou
       ]);
       const totalUnread = noticesData.unread_count + messagesData.unread_count;
       setUnreadCount(totalUnread);
-    } catch (error) {
-      console.error('Client operation failed');
+    } catch {
     }
   };
 
@@ -86,8 +90,7 @@ export default function ProtectedLayoutClient({ children, user }: ProtectedLayou
       const data = await messagesApi.getInbox({ is_read: false, limit: 3 });
       setRecentUnreadMessages(data.messages.slice(0, 3));
       setMessagesLoaded(true);
-    } catch (error) {
-      console.error('Client operation failed');
+    } catch {
     }
   };
 
@@ -96,8 +99,7 @@ export default function ProtectedLayoutClient({ children, user }: ProtectedLayou
     try {
       const data = await deadlineApi.getAlerts({ threshold_days: 30 });
       return data.alerts;
-    } catch (error) {
-      console.error('Client operation failed');
+    } catch {
       return null;
     }
   };
@@ -140,8 +142,7 @@ export default function ProtectedLayoutClient({ children, user }: ProtectedLayou
 
       setTotalDeadlineAlerts(data.total);
       setDeadlineAlertsOffset(offset + data.alerts.length);
-    } catch (error) {
-      console.error('Client operation failed');
+    } catch {
     }
   };
 
@@ -150,10 +151,21 @@ export default function ProtectedLayoutClient({ children, user }: ProtectedLayou
     fetchDeadlineAlerts(deadlineAlertsOffset);
   };
 
-  // ホバー時の処理
-  const handleNoticeHover = () => {
-    setIsNoticeHovered(true);
-    setNoticePopoverView('deadlines');
+  const hasDeadlineAttention = totalDeadlineAlerts > 0 || deadlineAlerts.length > 0;
+
+  const getDeadlineAlertStatusText = (alert: DeadlineAlert) => {
+    if (alert.alert_type === 'assessment_incomplete') {
+      return 'アセスメント未完了';
+    }
+    if (alert.alert_type === 'renewal_overdue') {
+      return '期限切れ';
+    }
+    return `残り${alert.days_remaining}日`;
+  };
+
+  // 通知/メッセージプレビューを開く
+  const handleNoticeToggle = () => {
+    setIsNoticePopoverOpen((isOpen) => !isOpen);
     fetchRecentUnreadMessages();
     // 更新期限のお知らせも取得（初回のみ）
     if (!deadlineAlertsLoaded) {
@@ -168,21 +180,18 @@ export default function ProtectedLayoutClient({ children, user }: ProtectedLayou
     setIsMounted(true);
 
     // CSRFトークンを初期化（ページリフレッシュ時に必要）
-    initializeCsrfToken().catch(error => {
-      console.error('Client operation failed');
-    });
+    initializeCsrfToken().catch(() => {});
 
     // 事業所情報が未取得の場合のみ取得
     if (!office) {
       officeApi.getMyOffice()
         .then(officeData => setOffice(officeData))
-        .catch(error => {
-          console.error('Client operation failed');
-        });
+        .catch(() => {});
     }
 
     // 初回の未読件数取得
     fetchUnreadCount();
+    fetchDeadlineAlerts(0);
 
     // 通知設定を取得し、トースト表示とPush購読を実行（ログイン時のみ、1回だけ）
     const initializeNotifications = async () => {
@@ -226,8 +235,7 @@ export default function ProtectedLayoutClient({ children, user }: ProtectedLayou
         ) {
           await subscribe();
         }
-      } catch (error) {
-        console.error('Client operation failed');
+      } catch {
         // エラー時も処理を継続（ユーザー体験に影響を与えない）
       }
     };
@@ -245,11 +253,37 @@ export default function ProtectedLayoutClient({ children, user }: ProtectedLayou
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
-  // イベントリスナー管理: ツールチップのクリックアウトサイド処理
   useEffect(() => {
-    const handleClickOutside = () => {
+    if (!isMounted || !hasDeadlineAttention || deadlineDrawerHintShownRef.current) {
+      return;
+    }
+
+    deadlineDrawerHintShownRef.current = true;
+    setShowDeadlineDrawerHint(true);
+
+    const timer = setTimeout(() => {
+      setShowDeadlineDrawerHint(false);
+    }, 5000);
+
+    return () => {
+      clearTimeout(timer);
+    };
+  }, [hasDeadlineAttention, isMounted]);
+
+  // イベントリスナー管理: ツールチップ/通知プレビューのクリックアウトサイド処理
+  useEffect(() => {
+    const handleClickOutside = (event: MouseEvent | TouchEvent) => {
       if (showOfficeTooltip) {
         setShowOfficeTooltip(false);
+      }
+      if (
+        isNoticePopoverOpen &&
+        noticePopoverRef.current &&
+        event.target instanceof Node &&
+        !noticePopoverRef.current.contains(event.target)
+      ) {
+        setIsNoticePopoverOpen(false);
+        setIsDeadlinePanelOpen(false);
       }
     };
 
@@ -260,7 +294,7 @@ export default function ProtectedLayoutClient({ children, user }: ProtectedLayou
       document.removeEventListener('click', handleClickOutside);
       document.removeEventListener('touchstart', handleClickOutside);
     };
-  }, [showOfficeTooltip]);
+  }, [isNoticePopoverOpen, showOfficeTooltip]);
 
   const handleLogout = async () => {
     try {
@@ -273,8 +307,7 @@ export default function ProtectedLayoutClient({ children, user }: ProtectedLayou
       // router.push()ではなくwindow.location.hrefを使用して完全なページリロードを強制
       // これにより、Cookie削除が確実に反映された状態でログインページが読み込まれる
       window.location.href = `/auth/login?${params.toString()}`;
-    } catch (error) {
-      console.error('Client operation failed');
+    } catch {
       // エラーが発生してもログイン画面にリダイレクト
       window.location.href = '/auth/login';
     }
@@ -377,18 +410,16 @@ export default function ProtectedLayoutClient({ children, user }: ProtectedLayou
                 >
                   プロフィール
                 </Link>
-                <div
-                  className="relative"
-                  onMouseEnter={handleNoticeHover}
-                  onMouseLeave={() => setIsNoticeHovered(false)}
-                >
+                <div className="relative" ref={noticePopoverRef}>
                   <button
-                    onClick={() => router.push('/notice')}
+                    type="button"
+                    onClick={handleNoticeToggle}
                     className={`relative flex flex-col items-center gap-1 p-2 rounded-md transition-colors ${
-                      pathname === '/notice'
+                      pathname === '/notice' || isNoticePopoverOpen
                         ? 'bg-blue-50 text-blue-800 dark:bg-gray-700 dark:text-white'
                         : 'text-slate-600 hover:text-slate-950 hover:bg-slate-100 dark:text-gray-400 dark:hover:text-white dark:hover:bg-gray-700'
                     }`}
+                    aria-expanded={isNoticePopoverOpen}
                     aria-label={unreadCount > 0 ? `${unreadCount}件の未読通知があります` : '通知'}
                   >
                     <div className="relative">
@@ -404,125 +435,152 @@ export default function ProtectedLayoutClient({ children, user }: ProtectedLayou
                   </button>
 
                   {/* 通知プレビューポップオーバー */}
-                  {isMounted && isNoticeHovered && (deadlineAlerts.length > 0 || recentUnreadMessages.length > 0) && (
+                  {isMounted && isNoticePopoverOpen && (
                     <div
-                      className="absolute right-0 top-full z-50 w-80 pt-2"
+                      className="absolute right-0 top-full z-50 w-[360px] pt-2"
                     >
                       <div className="rounded-lg border border-slate-300 bg-white p-4 shadow-xl dark:border-[#2a2a3e] dark:bg-[#0f1419]">
-                        <div className="mb-3 flex items-center justify-between gap-3">
-                          <h4 className="text-slate-900 font-semibold text-base dark:text-white">
-                            {noticePopoverView === 'deadlines' ? '更新期限が近い利用者' : '未読メッセージ'}
-                          </h4>
+                        <div className="mb-3 grid grid-cols-[auto_1fr_auto] items-center gap-3">
                           <button
                             type="button"
-                            onClick={(event) => {
-                              event.stopPropagation();
-                              setNoticePopoverView((view) => view === 'deadlines' ? 'messages' : 'deadlines');
+                            onClick={() => {
+                              setIsNoticePopoverOpen(false);
+                              setIsDeadlinePanelOpen(false);
                             }}
-                            className="shrink-0 rounded-md border border-blue-300 px-3 py-1.5 text-sm font-semibold text-blue-700 transition-colors hover:bg-blue-50 dark:border-blue-500/60 dark:text-blue-300 dark:hover:bg-blue-950/40"
+                            className="rounded-md px-2 py-1 text-base font-semibold text-slate-500 transition-colors hover:bg-slate-100 hover:text-slate-900 dark:text-gray-400 dark:hover:bg-gray-800 dark:hover:text-white"
+                            aria-label="通知/メッセージを閉じる"
                           >
-                            {noticePopoverView === 'deadlines' ? '通知/メッセージ' : '更新期限'}
+                            閉じる
+                          </button>
+                          <h4 className="text-center text-base font-semibold text-slate-900 dark:text-white">
+                            通知/メッセージ
+                          </h4>
+                          <span className="text-sm font-semibold text-slate-500 dark:text-gray-400">
+                            未読 {recentUnreadMessages.length}件
+                          </span>
+                        </div>
+                        <div className="mb-3 border-b border-slate-200 pb-3 dark:border-gray-700">
+                          <button
+                            onClick={() => router.push('/notice')}
+                            className="w-full rounded-md border border-blue-200 bg-blue-50 px-3 py-2 text-center text-base font-semibold text-blue-600 transition-colors hover:bg-blue-100 hover:text-blue-700 dark:border-blue-900/60 dark:bg-blue-950/30 dark:text-blue-400 dark:hover:bg-blue-950/50 dark:hover:text-blue-300"
+                          >
+                            通知/メッセージ画面を開く
                           </button>
                         </div>
 
-                        {noticePopoverView === 'deadlines' && (
-                          <>
-                            <div className="mb-3 flex items-center justify-end">
-                              <span className="text-base font-semibold text-slate-500 dark:text-gray-400">{totalDeadlineAlerts}件</span>
-                            </div>
-                            {deadlineAlerts.length > 0 ? (
-                              <div className="space-y-2">
-                                {deadlineAlerts.map((alert, index) => (
-                                  <div
-                                    key={`${alert.id}-${alert.alert_type || 'renewal'}-${index}`}
-                                    className="flex cursor-pointer items-center justify-between rounded-lg border border-slate-200 bg-slate-50 p-3 transition-colors hover:bg-slate-100 dark:border-gray-700/50 dark:bg-gray-800/50 dark:hover:bg-gray-800"
-                                    onClick={() => router.push(`/support_plan/${alert.id}`)}
-                                  >
-                                    <div className="flex min-w-0 items-center gap-2">
-                                      <span className="text-orange-400">⚠️</span>
-                                      <span className="truncate text-base font-semibold text-slate-900 dark:text-white">{alert.full_name}</span>
-                                    </div>
-                                    <div className="ml-2 flex shrink-0 items-center gap-2">
-                                      {alert.alert_type === 'assessment_incomplete' ? (
-                                        <span className="text-base font-semibold text-red-400">アセスメント未完了</span>
-                                      ) : alert.alert_type === 'renewal_overdue' ? (
-                                        <span className="text-base font-semibold text-red-400">期限切れ</span>
-                                      ) : (
-                                        <span className={`text-base font-semibold ${
-                                          (alert.days_remaining ?? 0) <= 15 ? 'text-red-400' :
-                                          (alert.days_remaining ?? 0) <= 25 ? 'text-orange-400' :
-                                          'text-yellow-500 dark:text-yellow-400'
-                                        }`}>
-                                          残り{alert.days_remaining}日
-                                        </span>
-                                      )}
-                                      <span className="text-gray-500">→</span>
-                                    </div>
-                                  </div>
-                                ))}
-                              </div>
-                            ) : (
-                              <p className="rounded-lg border border-slate-200 bg-slate-50 p-4 text-center text-base font-semibold text-slate-600 dark:border-gray-700/50 dark:bg-gray-800/50 dark:text-gray-300">
-                                更新期限が近い利用者はいません
-                              </p>
-                            )}
-                            {deadlineAlertsOffset < totalDeadlineAlerts && (
-                              <div className="mt-3 pt-3 border-t border-slate-200 dark:border-gray-700">
-                                <button
-                                  onClick={handleLoadMoreDeadlineAlerts}
-                                  className="w-full text-center text-blue-500 hover:text-blue-600 text-base font-semibold transition-colors dark:text-blue-400 dark:hover:text-blue-300"
-                                >
-                                  さらに表示
-                                </button>
-                              </div>
-                            )}
-                          </>
-                        )}
+                        <div className="mb-3 rounded-lg border border-yellow-300 bg-yellow-50 dark:border-yellow-600/60 dark:bg-yellow-950/20">
+                          <button
+                            type="button"
+                            onClick={() => setIsDeadlinePanelOpen((isOpen) => !isOpen)}
+                            className="flex w-full items-center justify-between gap-3 px-3 py-2.5 text-left"
+                            aria-expanded={isDeadlinePanelOpen}
+                          >
+                            <span className="flex min-w-0 items-center gap-2">
+                              <span className="truncate text-base font-semibold text-slate-900 dark:text-white">
+                                更新期限・アセスメント
+                              </span>
+                              <span className="shrink-0 text-sm font-semibold text-slate-600 dark:text-gray-300">
+                                {totalDeadlineAlerts}件
+                              </span>
+                            </span>
+                            <span className="flex shrink-0 items-center gap-1">
+                              <MdKeyboardArrowDown
+                                className={`h-6 w-6 text-slate-600 transition-transform duration-300 dark:text-gray-300 ${isDeadlinePanelOpen ? 'rotate-180' : ''}`}
+                                aria-hidden="true"
+                              />
+                            </span>
+                          </button>
 
-                        {noticePopoverView === 'messages' && (
-                          <>
-                            <div className="mb-3 flex items-center justify-end">
-                              <span className="text-base font-semibold text-slate-500 dark:text-gray-400">{recentUnreadMessages.length}件</span>
-                            </div>
-                            {recentUnreadMessages.length > 0 ? (
-                              <div className="space-y-2">
-                                {recentUnreadMessages.map((message) => (
-                                  <div
-                                    key={message.message_id}
-                                    className="cursor-pointer rounded-lg border border-slate-200 bg-slate-50 p-3 transition-colors hover:bg-slate-100 dark:border-gray-700/50 dark:bg-gray-800/50 dark:hover:bg-gray-800"
-                                    onClick={() => router.push('/notice')}
-                                  >
-                                    <div className="mb-1 flex items-start justify-between gap-2">
-                                      <h5 className="line-clamp-1 text-base font-semibold text-slate-900 dark:text-white">{message.title}</h5>
-                                      <span className="mt-1.5 inline-block h-2 w-2 shrink-0 rounded-full bg-blue-500"></span>
-                                    </div>
-                                    <p className="mb-2 line-clamp-2 text-base font-semibold text-slate-600 dark:text-gray-400">{message.content}</p>
-                                    <time className="text-base font-semibold text-slate-500 dark:text-gray-500">
-                                      {new Date(message.created_at).toLocaleString('ja-JP', {
-                                        month: 'short',
-                                        day: 'numeric',
-                                        hour: '2-digit',
-                                        minute: '2-digit',
-                                      })}
-                                    </time>
-                                  </div>
-                                ))}
+                          <div
+                            className={`grid transition-[grid-template-rows] duration-300 ease-in-out ${isDeadlinePanelOpen ? 'grid-rows-[1fr]' : 'grid-rows-[0fr]'}`}
+                          >
+                            <div className="overflow-hidden">
+                              <div className="space-y-2 border-t border-yellow-200 p-3 dark:border-yellow-700/50">
+                                {deadlineAlerts.length > 0 ? (
+                                  <>
+                                    {deadlineAlerts.map((alert, index) => (
+                                      <div
+                                        key={`${alert.id}-${alert.alert_type || 'renewal'}-${index}`}
+                                        className="flex cursor-pointer items-center justify-between rounded-lg border border-slate-200 bg-white p-3 transition-colors hover:bg-slate-100 dark:border-gray-700/50 dark:bg-gray-800/70 dark:hover:bg-gray-800"
+                                        onClick={() => router.push(`/support_plan/${alert.id}`)}
+                                      >
+                                        <div className="flex min-w-0 items-center gap-2">
+                                          <span className="truncate text-base font-semibold text-slate-900 dark:text-white">{alert.full_name}</span>
+                                        </div>
+                                        <div className="ml-2 flex shrink-0 items-center gap-2">
+                                          {alert.alert_type === 'assessment_incomplete' ? (
+                                            <span className="text-base font-semibold text-red-500 dark:text-red-400">アセスメント未完了</span>
+                                          ) : alert.alert_type === 'renewal_overdue' ? (
+                                            <span className="text-base font-semibold text-red-500 dark:text-red-400">期限切れ</span>
+                                          ) : (
+                                            <span className={`text-base font-semibold ${
+                                              (alert.days_remaining ?? 0) <= 15 ? 'text-red-500 dark:text-red-400' :
+                                              (alert.days_remaining ?? 0) <= 25 ? 'text-orange-500 dark:text-orange-400' :
+                                              'text-yellow-600 dark:text-yellow-400'
+                                            }`}>
+                                              残り{alert.days_remaining}日
+                                            </span>
+                                          )}
+                                          <span className="text-gray-500">→</span>
+                                        </div>
+                                      </div>
+                                    ))}
+                                    {deadlineAlertsOffset < totalDeadlineAlerts && (
+                                      <div className="pt-1">
+                                        <button
+                                          onClick={handleLoadMoreDeadlineAlerts}
+                                          className="w-full rounded-md border border-yellow-300 py-2 text-center text-base font-semibold text-yellow-700 transition-colors hover:bg-yellow-100 dark:border-yellow-700/60 dark:text-yellow-300 dark:hover:bg-yellow-950/40"
+                                        >
+                                          さらに表示
+                                        </button>
+                                      </div>
+                                    )}
+                                  </>
+                                ) : (
+                                  <p className="rounded-lg border border-slate-200 bg-white p-4 text-center text-base font-semibold text-slate-600 dark:border-gray-700/50 dark:bg-gray-800/50 dark:text-gray-300">
+                                    更新期限が近い利用者はいません
+                                  </p>
+                                )}
                               </div>
-                            ) : (
-                              <p className="rounded-lg border border-slate-200 bg-slate-50 p-4 text-center text-base font-semibold text-slate-600 dark:border-gray-700/50 dark:bg-gray-800/50 dark:text-gray-300">
-                                未読メッセージはありません
-                              </p>
-                            )}
-                            <div className="mt-3 pt-3 border-t border-slate-200 dark:border-gray-700">
-                              <button
-                                onClick={() => router.push('/notice')}
-                                className="w-full text-center text-blue-500 hover:text-blue-600 text-base font-semibold transition-colors dark:text-blue-400 dark:hover:text-blue-300"
-                              >
-                                通知/メッセージを開く
-                              </button>
                             </div>
-                          </>
-                        )}
+                          </div>
+                        </div>
+
+                        <div>
+                          <div className="mb-3 flex items-center justify-between">
+                            <h5 className="text-base font-semibold text-slate-900 dark:text-white">未読メッセージ</h5>
+                            <span className="text-base font-semibold text-slate-500 dark:text-gray-400">{recentUnreadMessages.length}件</span>
+                          </div>
+                          {recentUnreadMessages.length > 0 ? (
+                            <div className="space-y-2">
+                              {recentUnreadMessages.map((message) => (
+                                <div
+                                  key={message.message_id}
+                                  className="cursor-pointer rounded-lg border border-slate-200 bg-slate-50 p-3 transition-colors hover:bg-slate-100 dark:border-gray-700/50 dark:bg-gray-800/50 dark:hover:bg-gray-800"
+                                  onClick={() => router.push('/notice')}
+                                >
+                                  <div className="mb-1 flex items-start justify-between gap-2">
+                                    <h5 className="line-clamp-1 text-base font-semibold text-slate-900 dark:text-white">{message.title}</h5>
+                                    <span className="mt-1.5 inline-block h-2 w-2 shrink-0 rounded-full bg-blue-500"></span>
+                                  </div>
+                                  <p className="mb-2 line-clamp-2 text-base font-semibold text-slate-600 dark:text-gray-400">{message.content}</p>
+                                  <time className="text-base font-semibold text-slate-500 dark:text-gray-500">
+                                    {new Date(message.created_at).toLocaleString('ja-JP', {
+                                      month: 'short',
+                                      day: 'numeric',
+                                      hour: '2-digit',
+                                      minute: '2-digit',
+                                    })}
+                                  </time>
+                                </div>
+                              ))}
+                            </div>
+                          ) : (
+                            <p className="rounded-lg border border-slate-200 bg-slate-50 p-4 text-center text-base font-semibold text-slate-600 dark:border-gray-700/50 dark:bg-gray-800/50 dark:text-gray-300">
+                              未読メッセージはありません
+                            </p>
+                          )}
+                        </div>
                       </div>
                     </div>
                   )}
@@ -596,7 +654,9 @@ export default function ProtectedLayoutClient({ children, user }: ProtectedLayou
                       : 'text-slate-700 hover:text-slate-950 hover:bg-slate-100 dark:text-gray-300 dark:hover:text-white dark:hover:bg-gray-700'
                   }`}
                 >
-                  <span>通知/メッセージ</span>
+                  <span className="inline-flex items-center gap-2">
+                    通知/メッセージ
+                  </span>
                   {unreadCount > 0 && (
                     <span className="inline-flex items-center justify-center px-2 py-1 text-base font-bold leading-none text-white bg-red-600 rounded-full">
                       {unreadCount}
@@ -619,6 +679,85 @@ export default function ProtectedLayoutClient({ children, user }: ProtectedLayou
             )}
           </nav>
         </header>
+
+        {isMounted && hasDeadlineAttention && (
+          <aside className="fixed right-4 top-28 z-40 hidden md:block">
+            <div
+              className={`relative transition-all duration-300 ease-in-out ${
+                isDeadlineDrawerOpen ? 'w-80' : 'w-44'
+              }`}
+            >
+              {!isDeadlineDrawerOpen ? (
+                <button
+                  type="button"
+                  onClick={() => setIsDeadlineDrawerOpen(true)}
+                  className="relative ml-auto flex h-16 w-24 items-center justify-center border-4 border-yellow-500 bg-yellow-100 text-yellow-950 shadow-lg transition-colors hover:bg-yellow-200 dark:border-yellow-400 dark:bg-yellow-900/80 dark:text-yellow-50 dark:hover:bg-yellow-800"
+                  aria-label="更新期限アラートを開く"
+                >
+                  {showDeadlineDrawerHint && (
+                    <span className="pointer-events-none absolute -top-11 right-0 w-44 rounded-md border border-yellow-300 bg-yellow-50 px-3 py-1.5 text-center text-sm font-semibold text-slate-900 shadow-md dark:border-yellow-700/60 dark:bg-yellow-950 dark:text-white">
+                      更新期限が迫っています
+                      <span className="absolute -bottom-1 right-8 h-2 w-2 rotate-45 border-b border-r border-yellow-300 bg-yellow-50 dark:border-yellow-700/60 dark:bg-yellow-950" />
+                    </span>
+                  )}
+                  <MdWarning className="absolute -top-3 left-1 h-6 w-6 text-yellow-500" aria-hidden="true" />
+                  <span className="flex flex-col items-center text-sm font-bold leading-tight text-yellow-950 dark:text-yellow-50">
+                    <span>更新が必要な</span>
+                    <span>利用者</span>
+                  </span>
+                </button>
+              ) : (
+                <div className="max-h-[60vh] overflow-hidden rounded-md border border-yellow-300 bg-yellow-50 shadow-xl transition-all duration-300 ease-in-out dark:border-yellow-700/60 dark:bg-yellow-950/20">
+                  <button
+                    type="button"
+                    onClick={() => setIsDeadlineDrawerOpen(false)}
+                    className="absolute left-1 top-1 z-10 flex h-7 w-14 items-center justify-center rounded text-sm font-semibold leading-none text-red-700 transition-colors hover:bg-yellow-100 dark:text-red-400 dark:hover:bg-yellow-950/40"
+                    aria-label="更新期限アラートを閉じる"
+                  >
+                    閉じる
+                  </button>
+                  <div className="flex items-center justify-between gap-3 border-b border-yellow-200 px-4 py-3 pl-16 dark:border-yellow-700/50">
+                    <h4 className="truncate text-base font-semibold text-slate-900 dark:text-white">
+                      更新期限・アセスメント
+                    </h4>
+                    <span className="shrink-0 text-sm font-semibold text-slate-600 dark:text-gray-300">
+                      {totalDeadlineAlerts}件
+                    </span>
+                  </div>
+                  <div className="max-h-[calc(60vh-48px)] space-y-2 overflow-y-auto p-3">
+                    {deadlineAlerts.map((alert, index) => (
+                      <button
+                        key={`${alert.id}-${alert.alert_type || 'renewal'}-drawer-${index}`}
+                        type="button"
+                        onClick={() => router.push(`/support_plan/${alert.id}`)}
+                        className="flex w-full items-center justify-between gap-3 rounded-lg border border-slate-200 bg-white p-3 text-left transition-colors hover:bg-slate-100 dark:border-gray-700/50 dark:bg-gray-800/70 dark:hover:bg-gray-800"
+                      >
+                        <span className="min-w-0 truncate text-base font-semibold text-slate-900 dark:text-white">
+                          {alert.full_name}
+                        </span>
+                        <span className="flex shrink-0 items-center gap-2">
+                          <span className="text-base font-semibold text-red-500 dark:text-red-400">
+                            {getDeadlineAlertStatusText(alert)}
+                          </span>
+                          <span className="text-gray-500">→</span>
+                        </span>
+                      </button>
+                    ))}
+                    {deadlineAlertsOffset < totalDeadlineAlerts && (
+                      <button
+                        type="button"
+                        onClick={handleLoadMoreDeadlineAlerts}
+                        className="w-full rounded-md border border-yellow-300 bg-white py-2 text-center text-base font-semibold text-yellow-700 transition-colors hover:bg-yellow-100 dark:border-yellow-700/60 dark:bg-gray-800/70 dark:text-yellow-300 dark:hover:bg-yellow-950/40"
+                      >
+                        さらに表示
+                      </button>
+                    )}
+                  </div>
+                </div>
+              )}
+            </div>
+          </aside>
+        )}
 
         {/* Trial Expiry Banner */}
         <TrialExpiryBanner />

--- a/components/protected/admin/AdminMenu.tsx
+++ b/components/protected/admin/AdminMenu.tsx
@@ -236,13 +236,13 @@ export default function AdminMenu({ office }: AdminMenuProps) {
   const getRoleBadgeColor = (role: string) => {
     switch (role) {
       case 'owner':
-        return 'border-purple-500 text-purple-700 dark:text-purple-300';
+        return 'border-purple-300 bg-purple-50 text-purple-700 dark:border-purple-500 dark:bg-purple-950/30 dark:text-purple-300';
       case 'manager':
-        return 'border-blue-500 text-blue-700 dark:text-blue-300';
+        return 'border-blue-300 bg-blue-50 text-blue-700 dark:border-blue-500 dark:bg-blue-950/30 dark:text-blue-300';
       case 'employee':
-        return 'border-green-500 text-green-700 dark:text-green-300';
+        return 'border-green-300 bg-green-50 text-green-700 dark:border-green-500 dark:bg-green-950/30 dark:text-green-300';
       default:
-        return 'border-slate-400 text-slate-700 dark:text-slate-300';
+        return 'border-slate-300 bg-slate-50 text-slate-700 dark:border-slate-500 dark:bg-slate-800 dark:text-slate-300';
     }
   };
 
@@ -608,28 +608,28 @@ export default function AdminMenu({ office }: AdminMenuProps) {
               <h2 className="text-2xl font-bold mb-4">事業所設定</h2>
 
               {mfaSuccess && (
-                <div className="mb-4 p-4 bg-green-900/50 border border-green-500 rounded-lg">
-                  <p className="text-green-400 text-base">{mfaSuccess}</p>
+                <div className="mb-4 p-4 bg-green-50 border border-green-300 rounded-lg dark:bg-green-950/40 dark:border-green-700">
+                  <p className="text-green-700 text-base dark:text-green-300">{mfaSuccess}</p>
                 </div>
               )}
 
               {mfaError && (
-                <div className="mb-4 p-4 bg-red-900/50 border border-red-500 rounded-lg">
-                  <p className="text-red-400 text-base font-semibold">エラー</p>
-                  <p className="text-red-400 text-base font-semibold mt-1">{mfaError}</p>
+                <div className="mb-4 p-4 bg-red-50 border border-red-300 rounded-lg dark:bg-red-950/40 dark:border-red-700">
+                  <p className="text-red-700 text-base font-semibold dark:text-red-300">エラー</p>
+                  <p className="text-red-700 text-base font-semibold mt-1 dark:text-red-300">{mfaError}</p>
                 </div>
               )}
 
               {deleteStaffSuccess && (
-                <div className="mb-4 p-4 bg-green-900/50 border border-green-500 rounded-lg">
-                  <p className="text-green-400 text-base">{deleteStaffSuccess}</p>
+                <div className="mb-4 p-4 bg-green-50 border border-green-300 rounded-lg dark:bg-green-950/40 dark:border-green-700">
+                  <p className="text-green-700 text-base dark:text-green-300">{deleteStaffSuccess}</p>
                 </div>
               )}
 
               {deleteStaffError && (
-                <div className="mb-4 p-4 bg-red-900/50 border border-red-500 rounded-lg">
-                  <p className="text-red-400 text-base font-semibold">エラー</p>
-                  <p className="text-red-400 text-base font-semibold mt-1">{deleteStaffError}</p>
+                <div className="mb-4 p-4 bg-red-50 border border-red-300 rounded-lg dark:bg-red-950/40 dark:border-red-700">
+                  <p className="text-red-700 text-base font-semibold dark:text-red-300">エラー</p>
+                  <p className="text-red-700 text-base font-semibold mt-1 dark:text-red-300">{deleteStaffError}</p>
                 </div>
               )}
 
@@ -722,7 +722,7 @@ export default function AdminMenu({ office }: AdminMenuProps) {
               <p className="text-slate-600 text-base font-semibold dark:text-gray-400 mb-3">
                 QRコードをスキャンできない場合は、以下のキーを手動で入力してください。
               </p>
-              <div className="bg-slate-100 border border-slate-300 p-3 rounded font-mono text-base text-slate-900 dark:text-white break-all">
+              <div className="bg-slate-50 border border-slate-300 p-3 rounded font-mono text-base text-slate-900 dark:bg-gray-900 dark:border-gray-600 dark:text-white break-all">
                 {mfaSetupData.secret_key}
               </div>
             </div>
@@ -733,7 +733,7 @@ export default function AdminMenu({ office }: AdminMenuProps) {
               <p className="text-slate-600 text-base font-semibold dark:text-gray-400 mb-3">
                 端末を紛失した場合に使用できるバックアップコードです。安全な場所に保管してください。
               </p>
-              <div className="bg-slate-100 border border-slate-300 p-4 rounded">
+              <div className="bg-slate-50 border border-slate-300 p-4 rounded dark:bg-gray-900 dark:border-gray-600">
                 <div className="grid grid-cols-2 gap-2">
                   {mfaSetupData.recovery_codes.map((code, index) => (
                     <div key={index} className="font-mono text-base text-slate-900 dark:text-white">
@@ -789,15 +789,15 @@ export default function AdminMenu({ office }: AdminMenuProps) {
           <div className="bg-white rounded-lg border border-slate-300 shadow-xl dark:bg-gray-800 dark:border-gray-700 max-w-4xl w-full max-h-[90vh] overflow-y-auto">
             <div className="p-6 border-b border-slate-300 dark:border-gray-700">
               <h2 className="text-2xl font-bold text-slate-900 dark:text-white">２段階認証一括有効化結果</h2>
-              <p className="text-green-400 mt-2">
+              <p className="text-green-700 mt-2 dark:text-green-300">
                 {bulkMfaResultData.enabled_count}名のスタッフの２段階認証を有効化しました
               </p>
             </div>
 
             <div className="p-6">
-              <div className="mb-4 p-4 bg-yellow-900/50 border border-yellow-500 rounded-lg">
-                <p className="text-yellow-400 text-base font-semibold">重要</p>
-                <p className="text-yellow-400 text-base font-semibold mt-1">
+              <div className="mb-4 p-4 bg-yellow-50 border border-yellow-400 rounded-lg dark:bg-yellow-950/40 dark:border-yellow-600">
+                <p className="text-yellow-800 text-base font-semibold dark:text-yellow-300">重要</p>
+                <p className="text-yellow-800 text-base font-semibold mt-1 dark:text-yellow-300">
                   以下の情報を各スタッフに安全な方法で伝えてください。QRコードをスキャンしてTOTPアプリに登録し、リカバリーコードは安全な場所に保管してください。
                 </p>
               </div>
@@ -826,17 +826,17 @@ export default function AdminMenu({ office }: AdminMenuProps) {
                       <div>
                         <div className="mb-4">
                           <p className="text-slate-600 text-base font-semibold dark:text-gray-400 mb-2">シークレットキー</p>
-                          <code className="block bg-slate-900 text-green-300 p-2 rounded text-sm break-all dark:bg-gray-900 dark:text-green-400">
+                          <code className="block bg-slate-50 border border-slate-300 text-slate-900 p-2 rounded text-sm break-all dark:bg-gray-900 dark:border-gray-600 dark:text-green-300">
                             {staffData.secret_key}
                           </code>
                         </div>
 
                         <div>
                           <p className="text-slate-600 text-base font-semibold dark:text-gray-400 mb-2">リカバリーコード（10個）</p>
-                          <div className="bg-slate-900 border border-slate-700 p-3 rounded max-h-40 overflow-y-auto dark:bg-gray-900 dark:border-transparent">
+                          <div className="bg-slate-50 border border-slate-300 p-3 rounded max-h-40 overflow-y-auto dark:bg-gray-900 dark:border-gray-600">
                             <div className="grid grid-cols-2 gap-2">
                               {staffData.recovery_codes.map((code, codeIndex) => (
-                                <code key={codeIndex} className="text-green-400 text-sm">
+                                <code key={codeIndex} className="text-slate-900 text-sm dark:text-green-300">
                                   {code}
                                 </code>
                               ))}

--- a/components/protected/admin/OfficeInfoTab.tsx
+++ b/components/protected/admin/OfficeInfoTab.tsx
@@ -58,15 +58,15 @@ export default function OfficeInfoTab({
         </div>
       </div>
 
-      <div className="bg-white p-6 rounded-lg mt-6 border border-red-300 shadow-sm dark:bg-gray-800 dark:border-red-500/30">
+      <div className="bg-white p-6 rounded-lg mt-6 border border-red-300 shadow-sm dark:bg-gray-800 dark:border-red-700/60">
         <div className="flex items-center gap-3 mb-4">
-          <MdExitToApp className="w-6 h-6 text-red-400" />
-          <h3 className="text-xl font-semibold text-red-400">退会</h3>
+          <MdExitToApp className="w-6 h-6 text-red-600 dark:text-red-300" />
+          <h3 className="text-xl font-semibold text-red-700 dark:text-red-300">退会</h3>
         </div>
 
         {withdrawalSuccess && (
-          <div className="mb-4 p-4 bg-green-900/50 border border-green-500 rounded-lg">
-            <p className="text-green-400 text-base">{withdrawalSuccess}</p>
+          <div className="mb-4 p-4 bg-green-50 border border-green-300 rounded-lg dark:bg-green-950/40 dark:border-green-700">
+            <p className="text-green-700 text-base dark:text-green-300">{withdrawalSuccess}</p>
           </div>
         )}
 

--- a/components/protected/admin/StaffManagementTab.tsx
+++ b/components/protected/admin/StaffManagementTab.tsx
@@ -115,16 +115,16 @@ export default function StaffManagementTab({
       </div>
 
       {bulkMfaError && (
-        <div className="mb-4 p-4 bg-red-900/50 border border-red-500 rounded-lg">
-          <p className="text-red-400 text-base font-semibold">エラー</p>
-          <p className="text-red-400 text-base font-semibold mt-1">{bulkMfaError}</p>
+        <div className="mb-4 p-4 bg-red-50 border border-red-300 rounded-lg dark:bg-red-950/40 dark:border-red-700">
+          <p className="text-red-700 text-base font-semibold dark:text-red-300">エラー</p>
+          <p className="text-red-700 text-base font-semibold mt-1 dark:text-red-300">{bulkMfaError}</p>
         </div>
       )}
 
       {bulkMfaSuccess && !showBulkMfaResultModal && (
-        <div className="mb-4 p-4 bg-green-900/50 border border-green-500 rounded-lg">
-          <p className="text-green-400 text-base font-semibold">成功</p>
-          <p className="text-green-400 text-base font-semibold mt-1">{bulkMfaSuccess}</p>
+        <div className="mb-4 p-4 bg-green-50 border border-green-300 rounded-lg dark:bg-green-950/40 dark:border-green-700">
+          <p className="text-green-700 text-base font-semibold dark:text-green-300">成功</p>
+          <p className="text-green-700 text-base font-semibold mt-1 dark:text-green-300">{bulkMfaSuccess}</p>
         </div>
       )}
 
@@ -136,9 +136,9 @@ export default function StaffManagementTab({
       )}
 
       {loadStaffsError && !isLoadingStaffs && (
-        <div className="p-4 bg-red-900/50 border border-red-500 rounded-lg">
-          <p className="text-red-400 text-base font-semibold">読み込みエラー</p>
-          <p className="text-red-400 text-base font-semibold mt-1">{loadStaffsError}</p>
+        <div className="p-4 bg-red-50 border border-red-300 rounded-lg dark:bg-red-950/40 dark:border-red-700">
+          <p className="text-red-700 text-base font-semibold dark:text-red-300">読み込みエラー</p>
+          <p className="text-red-700 text-base font-semibold mt-1 dark:text-red-300">{loadStaffsError}</p>
         </div>
       )}
 
@@ -198,7 +198,7 @@ export default function StaffManagementTab({
                           {staff.full_name}
                         </span>
                         {isDeleted && (
-                          <span className="px-2 py-1 rounded-lg text-sm font-semibold bg-red-900/50 text-red-400 border border-red-500">
+                          <span className="px-2 py-1 rounded-lg text-sm font-semibold bg-red-50 text-red-700 border border-red-300 dark:bg-red-950/40 dark:text-red-300 dark:border-red-700">
                             削除済み - 残り{remainingDays}日で完全削除
                           </span>
                         )}
@@ -217,8 +217,8 @@ export default function StaffManagementTab({
                         <span
                           className={`inline-flex min-w-20 justify-center rounded border px-3 py-1 text-base font-semibold items-center gap-1 ${
                             staff.is_mfa_enabled
-                              ? 'border-green-500 text-green-700 dark:text-green-300'
-                              : 'border-slate-400 text-slate-600 dark:border-gray-500 dark:text-gray-300'
+                              ? 'border-green-300 bg-green-50 text-green-700 dark:border-green-500 dark:bg-green-950/30 dark:text-green-300'
+                              : 'border-slate-300 bg-slate-50 text-slate-600 dark:border-gray-500 dark:bg-gray-800 dark:text-gray-300'
                           }`}
                         >
                           {staff.is_mfa_enabled ? (

--- a/components/protected/admin/WithdrawalModal.tsx
+++ b/components/protected/admin/WithdrawalModal.tsx
@@ -65,8 +65,8 @@ export default function WithdrawalModal({
     <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-50 p-4">
       <div className="bg-white font-semibold border border-slate-300 rounded-lg p-6 max-w-lg w-full max-h-[90vh] overflow-y-auto dark:bg-gray-800 dark:border-gray-700">
         <div className="flex items-center gap-3 mb-4">
-          <div className="bg-red-500/20 p-3 rounded-full">
-            <FaExclamationTriangle className="w-6 h-6 text-red-400" />
+          <div className="bg-red-50 p-3 rounded-full border border-red-200 dark:bg-red-950/40 dark:border-red-700">
+            <FaExclamationTriangle className="w-6 h-6 text-red-600 dark:text-red-300" />
           </div>
           <div>
             <h3 className="text-xl font-bold text-slate-900 dark:text-white">退会申請</h3>
@@ -75,8 +75,8 @@ export default function WithdrawalModal({
         </div>
 
         {/* 警告メッセージ */}
-        <div className="bg-red-500/10 border border-red-500/20 rounded-lg p-4 mb-6">
-          <p className="text-red-400 text-base font-semibold mb-2">注意事項</p>
+        <div className="bg-red-50 border border-red-300 rounded-lg p-4 mb-6 dark:bg-red-950/40 dark:border-red-700">
+          <p className="text-red-700 text-base font-semibold mb-2 dark:text-red-300">注意事項</p>
           <ul className="text-red-700 text-base font-semibold space-y-1 list-disc list-inside dark:text-red-300">
             <li>退会申請後、アプリ管理者による承認が必要です</li>
             <li>承認されると事務所データは論理削除されます</li>
@@ -86,15 +86,15 @@ export default function WithdrawalModal({
         </div>
 
         {error && (
-          <div className="bg-red-500/10 border border-red-500/20 rounded-lg p-4 mb-4">
-            <p className="text-red-400 text-base font-semibold">{error}</p>
+          <div className="bg-red-50 border border-red-300 rounded-lg p-4 mb-4 dark:bg-red-950/40 dark:border-red-700">
+            <p className="text-red-700 text-base font-semibold dark:text-red-300">{error}</p>
           </div>
         )}
 
         <div className="space-y-4">
           <div>
             <label className="block text-base font-semibold text-slate-600 dark:text-gray-400 mb-2">
-              タイトル <span className="text-red-400">*</span>
+              タイトル <span className="text-red-600 dark:text-red-300">*</span>
             </label>
             <input
               type="text"
@@ -108,7 +108,7 @@ export default function WithdrawalModal({
 
           <div>
             <label className="block text-base font-semibold text-slate-600 dark:text-gray-400 mb-2">
-              退会理由 <span className="text-red-400">*</span>
+              退会理由 <span className="text-red-600 dark:text-red-300">*</span>
             </label>
             <textarea
               value={reason}
@@ -121,7 +121,7 @@ export default function WithdrawalModal({
 
           <div>
             <label className="block text-base font-semibold text-slate-600 dark:text-gray-400 mb-2">
-              確認のため「退会申請」と入力してください <span className="text-red-400">*</span>
+              確認のため「退会申請」と入力してください <span className="text-red-600 dark:text-red-300">*</span>
             </label>
             <input
               type="text"

--- a/components/protected/app-admin/AppAdminDashboard.tsx
+++ b/components/protected/app-admin/AppAdminDashboard.tsx
@@ -1,10 +1,8 @@
 'use client';
 
 import { useState } from 'react';
-import { useRouter } from 'next/navigation';
 import { StaffResponse } from '@/types/staff';
-import { authApi } from '@/lib/auth';
-import { MdAdminPanelSettings, MdLogout } from 'react-icons/md';
+import { MdAdminPanelSettings } from 'react-icons/md';
 import { FaHistory, FaEnvelope, FaCheckCircle, FaBullhorn, FaBuilding } from 'react-icons/fa';
 import AuditLogTab from './tabs/AuditLogTab';
 import InquiriesTab from './tabs/InquiriesTab';
@@ -20,20 +18,6 @@ type TabType = 'logs' | 'inquiries' | 'approvals' | 'announcements' | 'offices';
 
 export default function AppAdminDashboard({ staff }: AppAdminDashboardProps) {
   const [activeTab, setActiveTab] = useState<TabType>('logs');
-  const [isLoggingOut, setIsLoggingOut] = useState(false);
-  const router = useRouter();
-
-  const handleLogout = async () => {
-    setIsLoggingOut(true);
-    try {
-      await authApi.logout();
-      router.push('/auth/app-admin/login');
-    } catch (error) {
-      console.error('Client operation failed');
-    } finally {
-      setIsLoggingOut(false);
-    }
-  };
 
   const tabs: { id: TabType; label: string; icon: React.ReactNode }[] = [
     { id: 'logs', label: 'ログ', icon: <FaHistory className="w-4 h-4" /> },
@@ -44,36 +28,28 @@ export default function AppAdminDashboard({ staff }: AppAdminDashboardProps) {
   ];
 
   return (
-    <div className="min-h-screen bg-gray-900 text-gray-200 font-semibold">
+    <div className="min-h-screen bg-slate-50 text-slate-900 font-semibold dark:bg-gray-900 dark:text-gray-200">
       {/* ヘッダー */}
-      <header className="bg-gray-800 border-b border-purple-500/30 px-6 py-4">
+      <header className="bg-white border-b border-slate-200 px-6 py-4 shadow-sm dark:bg-gray-800 dark:border-purple-500/30 dark:shadow-none">
         <div className="flex items-center justify-between">
           <div className="flex items-center gap-3">
             <MdAdminPanelSettings className="h-8 w-8 text-purple-500" />
             <div>
-              <h1 className="text-3xl font-bold text-white">アプリ管理コンソール</h1>
-              <p className="text-base font-semibold text-gray-300">ケイカくん管理者向けダッシュボード</p>
+              <h1 className="text-3xl font-bold text-slate-950 dark:text-white">アプリ管理コンソール</h1>
+              <p className="text-base font-semibold text-slate-600 dark:text-gray-300">ケイカくん管理者向けダッシュボード</p>
             </div>
           </div>
           <div className="flex items-center gap-4">
             <div className="text-right">
-              <p className="text-base font-semibold text-white">{staff.full_name}</p>
+              <p className="text-base font-semibold text-slate-950 dark:text-white">{staff.full_name}</p>
               <p className="text-base font-semibold text-purple-400">アプリ管理者</p>
             </div>
-            <button
-              onClick={handleLogout}
-              disabled={isLoggingOut}
-              className="flex items-center gap-2 bg-gray-700 hover:bg-gray-600 text-white px-4 py-2.5 rounded-lg text-base font-semibold transition-colors disabled:opacity-50"
-            >
-              <MdLogout className="w-5 h-5" />
-              {isLoggingOut ? 'ログアウト中...' : 'ログアウト'}
-            </button>
           </div>
         </div>
       </header>
 
       {/* タブナビゲーション */}
-      <div className="bg-gray-800 border-b border-gray-700">
+      <div className="bg-white border-b border-slate-200 dark:bg-gray-800 dark:border-gray-700">
         <div className="flex overflow-x-auto">
           {tabs.map((tab) => (
             <button
@@ -81,8 +57,8 @@ export default function AppAdminDashboard({ staff }: AppAdminDashboardProps) {
               onClick={() => setActiveTab(tab.id)}
               className={`flex items-center gap-2 px-6 py-3 text-base font-semibold whitespace-nowrap transition-colors ${
                 activeTab === tab.id
-                  ? 'bg-gray-900 text-purple-400 border-b-2 border-purple-500'
-                  : 'text-gray-400 hover:text-white hover:bg-gray-700/50'
+                  ? 'bg-purple-50 text-purple-700 border-b-2 border-purple-500 dark:bg-gray-900 dark:text-purple-400'
+                  : 'text-slate-600 hover:text-slate-950 hover:bg-slate-100 dark:text-gray-400 dark:hover:text-white dark:hover:bg-gray-700/50'
               }`}
             >
               {tab.icon}

--- a/components/protected/app-admin/OfficePreview.tsx
+++ b/components/protected/app-admin/OfficePreview.tsx
@@ -74,10 +74,10 @@ export default function OfficePreview({ officeId }: OfficePreviewProps) {
 
   if (isLoading) {
     return (
-      <div className="min-h-screen bg-gray-900 flex items-center justify-center">
+      <div className="min-h-screen bg-slate-100 flex items-center justify-center dark:bg-gray-900">
         <div className="text-center">
           <div className="animate-spin rounded-full h-12 w-12 border-t-2 border-b-2 border-purple-400 mx-auto"></div>
-          <p className="text-gray-400 mt-4">読み込み中...</p>
+          <p className="text-slate-600 mt-4 dark:text-gray-400">読み込み中...</p>
         </div>
       </div>
     );
@@ -85,10 +85,10 @@ export default function OfficePreview({ officeId }: OfficePreviewProps) {
 
   if (error) {
     return (
-      <div className="min-h-screen bg-gray-900 p-6">
+      <div className="min-h-screen bg-slate-100 p-6 dark:bg-gray-900">
         <button
           onClick={() => router.push('/app-admin')}
-          className="flex items-center gap-2 text-gray-400 hover:text-white mb-6 transition-colors"
+          className="flex items-center gap-2 text-slate-600 hover:text-slate-950 mb-6 transition-colors dark:text-gray-400 dark:hover:text-white"
         >
           <FaArrowLeft className="w-4 h-4" />
           戻る
@@ -105,12 +105,12 @@ export default function OfficePreview({ officeId }: OfficePreviewProps) {
   }
 
   return (
-    <div className="min-h-screen bg-gray-900 text-gray-200 p-6">
+    <div className="min-h-screen bg-slate-100 text-slate-900 p-6 dark:bg-gray-900 dark:text-gray-200">
       {/* ヘッダー */}
       <div className="mb-6">
         <button
           onClick={() => router.push('/app-admin')}
-          className="flex items-center gap-2 text-gray-400 hover:text-white mb-4 transition-colors"
+          className="flex items-center gap-2 text-slate-600 hover:text-slate-950 mb-4 transition-colors dark:text-gray-400 dark:hover:text-white"
         >
           <FaArrowLeft className="w-4 h-4" />
           事務所一覧に戻る
@@ -118,8 +118,8 @@ export default function OfficePreview({ officeId }: OfficePreviewProps) {
         <div className="flex items-center gap-3">
           <FaBuilding className="w-8 h-8 text-purple-400" />
           <div>
-            <h1 className="text-3xl font-bold text-white">{office.name}</h1>
-            <span className="bg-gray-600 text-gray-200 px-2 py-1 rounded text-base">
+            <h1 className="text-3xl font-bold text-slate-950 dark:text-white">{office.name}</h1>
+            <span className="bg-slate-200 text-slate-700 px-2 py-1 rounded text-base dark:bg-gray-600 dark:text-gray-200">
               {getOfficeTypeName(office.office_type)}
             </span>
           </div>
@@ -128,51 +128,51 @@ export default function OfficePreview({ officeId }: OfficePreviewProps) {
 
       <div className="grid grid-cols-1 lg:grid-cols-3 gap-6">
         {/* 事務所基本情報 */}
-        <div className="bg-gray-800 rounded-lg border border-gray-700 p-6">
-          <h2 className="text-xl font-bold text-white mb-4">基本情報</h2>
+        <div className="bg-white rounded-lg border border-slate-300 p-6 dark:bg-gray-800 dark:border-gray-700">
+          <h2 className="text-xl font-bold text-slate-950 mb-4 dark:text-white">基本情報</h2>
           <div className="space-y-4">
             <div>
-              <p className="text-base text-gray-400">住所</p>
-              <p className="text-white">{office.address || '未設定'}</p>
+              <p className="text-base text-slate-500 dark:text-gray-400">住所</p>
+              <p className="text-slate-950 dark:text-white">{office.address || '未設定'}</p>
             </div>
             <div>
-              <p className="text-base text-gray-400">電話番号</p>
-              <p className="text-white">{office.phone_number || '未設定'}</p>
+              <p className="text-base text-slate-500 dark:text-gray-400">電話番号</p>
+              <p className="text-slate-950 dark:text-white">{office.phone_number || '未設定'}</p>
             </div>
             <div>
-              <p className="text-base text-gray-400">メールアドレス</p>
-              <p className="text-white">{office.email || '未設定'}</p>
+              <p className="text-base text-slate-500 dark:text-gray-400">メールアドレス</p>
+              <p className="text-slate-950 dark:text-white">{office.email || '未設定'}</p>
             </div>
           </div>
         </div>
 
         {/* 統計情報 */}
-        <div className="bg-gray-800 rounded-lg border border-gray-700 p-6">
-          <h2 className="text-xl font-bold text-white mb-4">統計</h2>
+        <div className="bg-white rounded-lg border border-slate-300 p-6 dark:bg-gray-800 dark:border-gray-700">
+          <h2 className="text-xl font-bold text-slate-950 mb-4 dark:text-white">統計</h2>
           <div className="grid grid-cols-2 gap-4">
-            <div className="bg-gray-700/50 rounded-lg p-4 text-center">
+            <div className="bg-slate-100 rounded-lg p-4 text-center dark:bg-gray-700/50">
               <FaUsers className="w-6 h-6 text-blue-400 mx-auto mb-2" />
-              <p className="text-3xl font-bold text-white">{office.staffs.length}</p>
-              <p className="text-base text-gray-400">スタッフ数</p>
+              <p className="text-3xl font-bold text-slate-950 dark:text-white">{office.staffs.length}</p>
+              <p className="text-base text-slate-500 dark:text-gray-400">スタッフ数</p>
             </div>
-            <div className="bg-gray-700/50 rounded-lg p-4 text-center">
+            <div className="bg-slate-100 rounded-lg p-4 text-center dark:bg-gray-700/50">
               <FaCheckCircle className="w-6 h-6 text-green-400 mx-auto mb-2" />
-              <p className="text-3xl font-bold text-white">
+              <p className="text-3xl font-bold text-slate-950 dark:text-white">
                 {office.staffs.filter(s => s.is_email_verified).length}
               </p>
-              <p className="text-base text-gray-400">メール認証済み</p>
+              <p className="text-base text-slate-500 dark:text-gray-400">メール認証済み</p>
             </div>
           </div>
           <div className="mt-4">
             <div className="flex items-center justify-between text-base mb-1">
-              <span className="text-gray-400">メール認証率</span>
-              <span className="text-white">
+              <span className="text-slate-500 dark:text-gray-400">メール認証率</span>
+              <span className="text-slate-950 dark:text-white">
                 {office.staffs.length > 0
                   ? Math.round((office.staffs.filter(s => s.is_email_verified).length / office.staffs.length) * 100)
                   : 0}%
               </span>
             </div>
-            <div className="w-full bg-gray-700 rounded-full h-2">
+            <div className="w-full bg-slate-200 rounded-full h-2 dark:bg-gray-700">
               <div
                 className="bg-green-500 h-2 rounded-full transition-all"
                 style={{
@@ -186,47 +186,47 @@ export default function OfficePreview({ officeId }: OfficePreviewProps) {
         </div>
 
         {/* クイックアクション */}
-        <div className="bg-gray-800 rounded-lg border border-gray-700 p-6">
-          <h2 className="text-xl font-bold text-white mb-4">アクション</h2>
-          <p className="text-gray-400 text-base">
+        <div className="bg-white rounded-lg border border-slate-300 p-6 dark:bg-gray-800 dark:border-gray-700">
+          <h2 className="text-xl font-bold text-slate-950 mb-4 dark:text-white">アクション</h2>
+          <p className="text-slate-500 text-base dark:text-gray-400">
             この事務所に対するアクションは、各機能タブから実行できます。
           </p>
         </div>
       </div>
 
       {/* スタッフ一覧 */}
-      <div className="mt-6 bg-gray-800 rounded-lg border border-gray-700">
-        <div className="p-4 border-b border-gray-700">
-          <h2 className="text-xl font-bold text-white flex items-center gap-2">
+      <div className="mt-6 bg-white rounded-lg border border-slate-300 dark:bg-gray-800 dark:border-gray-700">
+        <div className="p-4 border-b border-slate-200 dark:border-gray-700">
+          <h2 className="text-xl font-bold text-slate-950 flex items-center gap-2 dark:text-white">
             <FaUsers className="w-5 h-5 text-purple-400" />
             スタッフ一覧
           </h2>
         </div>
         {office.staffs.length === 0 ? (
           <div className="p-8 text-center">
-            <p className="text-gray-400">スタッフが登録されていません</p>
+            <p className="text-slate-600 dark:text-gray-400">スタッフが登録されていません</p>
           </div>
         ) : (
           <div className="overflow-x-auto">
             <table className="w-full">
-              <thead className="bg-gray-700">
+              <thead className="bg-slate-100 dark:bg-gray-700">
                 <tr>
-                  <th className="text-left py-3 px-4 text-gray-300 font-semibold">氏名</th>
-                  <th className="text-left py-3 px-4 text-gray-300 font-semibold">メールアドレス</th>
-                  <th className="text-left py-3 px-4 text-gray-300 font-semibold">役割</th>
-                  <th className="text-left py-3 px-4 text-gray-300 font-semibold">MFA</th>
-                  <th className="text-left py-3 px-4 text-gray-300 font-semibold">メール認証</th>
+                  <th className="text-left py-3 px-4 text-slate-700 font-semibold dark:text-gray-300">氏名</th>
+                  <th className="text-left py-3 px-4 text-slate-700 font-semibold dark:text-gray-300">メールアドレス</th>
+                  <th className="text-left py-3 px-4 text-slate-700 font-semibold dark:text-gray-300">役割</th>
+                  <th className="text-left py-3 px-4 text-slate-700 font-semibold dark:text-gray-300">MFA</th>
+                  <th className="text-left py-3 px-4 text-slate-700 font-semibold dark:text-gray-300">メール認証</th>
                 </tr>
               </thead>
               <tbody>
                 {office.staffs.map((staff) => (
-                  <tr key={staff.id} className="border-t border-gray-700 hover:bg-gray-700/50">
+                  <tr key={staff.id} className="border-t border-slate-200 hover:bg-slate-50 dark:border-gray-700 dark:hover:bg-gray-700/50">
                     <td className="py-3 px-4">
-                      <span className="text-white">
+                      <span className="text-slate-950 dark:text-white">
                         {staff.full_name}
                       </span>
                     </td>
-                    <td className="py-3 px-4 text-gray-300 text-base">
+                    <td className="py-3 px-4 text-slate-700 text-base dark:text-gray-300">
                       {staff.email}
                     </td>
                     <td className="py-3 px-4">
@@ -241,7 +241,7 @@ export default function OfficePreview({ officeId }: OfficePreviewProps) {
                           有効
                         </span>
                       ) : (
-                        <span className="flex items-center gap-1 text-gray-400 text-base">
+                        <span className="flex items-center gap-1 text-slate-500 text-base dark:text-gray-400">
                           <FaTimesCircle className="w-4 h-4" />
                           無効
                         </span>

--- a/components/protected/app-admin/tabs/AnnouncementsTab.tsx
+++ b/components/protected/app-admin/tabs/AnnouncementsTab.tsx
@@ -91,7 +91,7 @@ export default function AnnouncementsTab() {
           <button
             onClick={fetchAnnouncements}
             disabled={isLoading}
-            className="flex items-center gap-2 bg-gray-700 hover:bg-gray-600 text-white px-4 py-2 rounded-lg transition-colors disabled:opacity-50"
+            className="flex items-center gap-2 bg-slate-200 hover:bg-slate-300 text-slate-900 px-4 py-2 rounded-lg transition-colors disabled:opacity-50 dark:bg-gray-700 dark:hover:bg-gray-600 dark:text-white"
           >
             <FaSync className={`w-4 h-4 ${isLoading ? 'animate-spin' : ''}`} />
             更新
@@ -113,11 +113,11 @@ export default function AnnouncementsTab() {
 
       {/* 新規作成フォーム */}
       {showForm && (
-        <div className="bg-gray-800 rounded-lg border border-purple-500/30 p-6 mb-6">
-          <h3 className="text-xl font-bold text-white mb-4">新規お知らせを作成</h3>
+        <div className="bg-white rounded-lg border border-purple-300 p-6 mb-6 dark:bg-gray-800 dark:border-purple-500/30">
+          <h3 className="text-xl font-bold text-slate-950 mb-4 dark:text-white">新規お知らせを作成</h3>
           <div className="space-y-4">
             <div>
-              <label className="block text-base text-gray-400 mb-2">
+              <label className="block text-base text-slate-600 mb-2 dark:text-gray-400">
                 タイトル <span className="text-red-400">*</span>
               </label>
               <input
@@ -125,18 +125,18 @@ export default function AnnouncementsTab() {
                 value={title}
                 onChange={(e) => setTitle(e.target.value)}
                 placeholder="お知らせのタイトル"
-                className="w-full bg-gray-700 border border-gray-600 rounded-lg px-3 py-2 text-white placeholder-gray-500"
+                className="w-full bg-white border border-slate-300 rounded-lg px-3 py-2 text-slate-900 placeholder-slate-400 dark:bg-gray-700 dark:border-gray-600 dark:text-white dark:placeholder-gray-500"
               />
             </div>
             <div>
-              <label className="block text-base text-gray-400 mb-2">
+              <label className="block text-base text-slate-600 mb-2 dark:text-gray-400">
                 本文 <span className="text-red-400">*</span>
               </label>
               <textarea
                 value={content}
                 onChange={(e) => setContent(e.target.value)}
                 placeholder="お知らせの本文を入力..."
-                className="w-full bg-gray-700 border border-gray-600 rounded-lg px-3 py-2 text-white placeholder-gray-500 h-32 resize-none"
+                className="w-full bg-white border border-slate-300 rounded-lg px-3 py-2 text-slate-900 placeholder-slate-400 h-32 resize-none dark:bg-gray-700 dark:border-gray-600 dark:text-white dark:placeholder-gray-500"
               />
             </div>
             <div className="flex justify-end gap-2">
@@ -146,7 +146,7 @@ export default function AnnouncementsTab() {
                   setTitle('');
                   setContent('');
                 }}
-                className="bg-gray-600 hover:bg-gray-500 text-white px-4 py-2 rounded-lg transition-colors"
+                className="bg-slate-200 hover:bg-slate-300 text-slate-900 px-4 py-2 rounded-lg transition-colors dark:bg-gray-600 dark:hover:bg-gray-500 dark:text-white"
               >
                 キャンセル
               </button>
@@ -164,34 +164,34 @@ export default function AnnouncementsTab() {
       )}
 
       {/* お知らせ履歴 */}
-      <div className="bg-gray-800 rounded-lg border border-gray-700">
-        <div className="p-4 border-b border-gray-700">
-          <h3 className="text-xl font-semibold text-white">送信履歴</h3>
+      <div className="bg-white rounded-lg border border-slate-300 dark:bg-gray-800 dark:border-gray-700">
+        <div className="p-4 border-b border-slate-200 dark:border-gray-700">
+          <h3 className="text-xl font-semibold text-slate-950 dark:text-white">送信履歴</h3>
         </div>
         {isLoading ? (
           <div className="p-8 text-center">
             <div className="animate-spin rounded-full h-8 w-8 border-t-2 border-b-2 border-purple-400 mx-auto"></div>
-            <p className="text-gray-400 mt-4">読み込み中...</p>
+            <p className="text-slate-600 mt-4 dark:text-gray-400">読み込み中...</p>
           </div>
         ) : announcements.length === 0 ? (
           <div className="p-8 text-center">
-            <p className="text-gray-400">お知らせの履歴がありません</p>
+            <p className="text-slate-600 dark:text-gray-400">お知らせの履歴がありません</p>
           </div>
         ) : (
-          <div className="divide-y divide-gray-700">
+          <div className="divide-y divide-slate-200 dark:divide-gray-700">
             {announcements.map((announcement) => (
-              <div key={announcement.id} className="p-4 hover:bg-gray-700/50">
+              <div key={announcement.id} className="p-4 hover:bg-slate-50 dark:hover:bg-gray-700/50">
                 <div className="flex items-start gap-3">
                   <FaBullhorn className="w-5 h-5 text-purple-400 mt-1 flex-shrink-0" />
                   <div className="flex-1">
                     <div className="flex items-center justify-between mb-1">
-                      <h4 className="font-semibold text-white">{announcement.title}</h4>
-                      <span className="text-base text-gray-400">
+                      <h4 className="font-semibold text-slate-950 dark:text-white">{announcement.title}</h4>
+                      <span className="text-base text-slate-500 dark:text-gray-400">
                         {formatDate(announcement.created_at)}
                       </span>
                     </div>
-                    <p className="text-gray-300 text-base whitespace-pre-wrap">{announcement.content}</p>
-                    <p className="text-base text-gray-400 mt-2">
+                    <p className="text-slate-700 text-base whitespace-pre-wrap dark:text-gray-300">{announcement.content}</p>
+                    <p className="text-base text-slate-500 mt-2 dark:text-gray-400">
                       送信者: {announcement.sender_name}
                     </p>
                   </div>
@@ -205,21 +205,21 @@ export default function AnnouncementsTab() {
       {/* ページネーション */}
       {totalPages > 1 && (
         <div className="flex items-center justify-between mt-4">
-          <p className="text-gray-400 text-base">
+          <p className="text-slate-600 text-base dark:text-gray-400">
             全 {total} 件中 {currentPage * ITEMS_PER_PAGE + 1} - {Math.min((currentPage + 1) * ITEMS_PER_PAGE, total)} 件を表示
           </p>
           <div className="flex gap-2">
             <button
               onClick={() => setCurrentPage(currentPage - 1)}
               disabled={currentPage === 0}
-              className="bg-gray-700 hover:bg-gray-600 text-white px-4 py-2 rounded-lg transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+              className="bg-slate-200 hover:bg-slate-300 text-slate-900 px-4 py-2 rounded-lg transition-colors disabled:opacity-50 disabled:cursor-not-allowed dark:bg-gray-700 dark:hover:bg-gray-600 dark:text-white"
             >
               前へ
             </button>
             <button
               onClick={() => setCurrentPage(currentPage + 1)}
               disabled={currentPage >= totalPages - 1}
-              className="bg-gray-700 hover:bg-gray-600 text-white px-4 py-2 rounded-lg transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+              className="bg-slate-200 hover:bg-slate-300 text-slate-900 px-4 py-2 rounded-lg transition-colors disabled:opacity-50 disabled:cursor-not-allowed dark:bg-gray-700 dark:hover:bg-gray-600 dark:text-white"
             >
               次へ
             </button>

--- a/components/protected/app-admin/tabs/ApprovalRequestsTab.tsx
+++ b/components/protected/app-admin/tabs/ApprovalRequestsTab.tsx
@@ -112,7 +112,7 @@ export default function ApprovalRequestsTab() {
               setStatusFilter(e.target.value as typeof statusFilter);
               setCurrentPage(0);
             }}
-            className="bg-gray-700 border border-gray-600 rounded-lg px-3 py-2 text-white"
+            className="bg-white border border-slate-300 rounded-lg px-3 py-2 text-slate-900 dark:bg-gray-700 dark:border-gray-600 dark:text-white"
           >
             <option value="">すべて</option>
             <option value="pending">承認待ち</option>
@@ -136,39 +136,39 @@ export default function ApprovalRequestsTab() {
         </div>
       )}
 
-      <div className="bg-gray-800 rounded-lg border border-gray-700">
+      <div className="bg-white rounded-lg border border-slate-300 dark:bg-gray-800 dark:border-gray-700">
         {isLoading ? (
           <div className="p-8 text-center">
             <div className="animate-spin rounded-full h-8 w-8 border-t-2 border-b-2 border-purple-400 mx-auto"></div>
-            <p className="text-gray-400 mt-4">読み込み中...</p>
+            <p className="text-slate-600 mt-4 dark:text-gray-400">読み込み中...</p>
           </div>
         ) : requests.length === 0 ? (
           <div className="p-8 text-center">
-            <p className="text-gray-400">退会リクエストがありません</p>
+            <p className="text-slate-600 dark:text-gray-400">退会リクエストがありません</p>
           </div>
         ) : (
-          <div className="divide-y divide-gray-700">
+          <div className="divide-y divide-slate-200 dark:divide-gray-700">
             {requests.map((request) => (
-              <div key={request.id} className="p-4 hover:bg-gray-700/50">
+              <div key={request.id} className="p-4 hover:bg-slate-50 dark:hover:bg-gray-700/50">
                 <div className="flex items-start justify-between">
                   <div className="flex-1">
                     <div className="flex items-center gap-2 mb-2">
                       <FaExclamationTriangle className="w-4 h-4 text-yellow-400" />
-                      <span className="font-semibold text-white">{request.title}</span>
+                      <span className="font-semibold text-slate-950 dark:text-white">{request.title}</span>
                       {getStatusBadge(request.status)}
                     </div>
-                    <p className="text-gray-300 text-base mb-2">{request.reason}</p>
-                    <div className="flex items-center gap-4 text-base text-gray-400">
+                    <p className="text-slate-700 text-base mb-2 dark:text-gray-300">{request.reason}</p>
+                    <div className="flex items-center gap-4 text-base text-slate-500 dark:text-gray-400">
                       <span>事務所: {request.office_name}</span>
                       <span>申請者: {request.requester_name}</span>
                       <span>申請日: {formatDate(request.created_at)}</span>
                     </div>
                     {request.reviewer_notes && (
-                      <div className="mt-3 p-3 bg-gray-700/50 rounded-lg">
-                        <p className="text-base text-gray-400 mb-1">
+                      <div className="mt-3 p-3 bg-slate-100 rounded-lg dark:bg-gray-700/50">
+                        <p className="text-base text-slate-500 mb-1 dark:text-gray-400">
                           {request.status === 'approved' ? '承認者コメント' : '却下理由'}:
                         </p>
-                        <p className="text-gray-300 text-base">{request.reviewer_notes}</p>
+                        <p className="text-slate-700 text-base dark:text-gray-300">{request.reviewer_notes}</p>
                       </div>
                     )}
                   </div>
@@ -203,21 +203,21 @@ export default function ApprovalRequestsTab() {
       {/* ページネーション */}
       {totalPages > 1 && (
         <div className="flex items-center justify-between mt-4">
-          <p className="text-gray-400 text-base">
+          <p className="text-slate-600 text-base dark:text-gray-400">
             全 {total} 件中 {currentPage * ITEMS_PER_PAGE + 1} - {Math.min((currentPage + 1) * ITEMS_PER_PAGE, total)} 件を表示
           </p>
           <div className="flex gap-2">
             <button
               onClick={() => setCurrentPage(currentPage - 1)}
               disabled={currentPage === 0}
-              className="bg-gray-700 hover:bg-gray-600 text-white px-4 py-2 rounded-lg transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+              className="bg-slate-200 hover:bg-slate-300 text-slate-900 px-4 py-2 rounded-lg transition-colors disabled:opacity-50 disabled:cursor-not-allowed dark:bg-gray-700 dark:hover:bg-gray-600 dark:text-white"
             >
               前へ
             </button>
             <button
               onClick={() => setCurrentPage(currentPage + 1)}
               disabled={currentPage >= totalPages - 1}
-              className="bg-gray-700 hover:bg-gray-600 text-white px-4 py-2 rounded-lg transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+              className="bg-slate-200 hover:bg-slate-300 text-slate-900 px-4 py-2 rounded-lg transition-colors disabled:opacity-50 disabled:cursor-not-allowed dark:bg-gray-700 dark:hover:bg-gray-600 dark:text-white"
             >
               次へ
             </button>
@@ -228,10 +228,10 @@ export default function ApprovalRequestsTab() {
       {/* 承認確認モーダル */}
       {showApproveConfirm && selectedRequest && (
         <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-50 p-4">
-          <div className="bg-gray-800 rounded-lg p-6 max-w-lg w-full">
+          <div className="bg-white rounded-lg p-6 max-w-lg w-full dark:bg-gray-800">
             <div className="flex items-center gap-3 mb-4">
               <FaExclamationTriangle className="w-8 h-8 text-yellow-400" />
-              <h3 className="text-2xl font-bold text-white">退会承認の確認</h3>
+              <h3 className="text-2xl font-bold text-slate-950 dark:text-white">退会承認の確認</h3>
             </div>
             <div className="bg-red-500/10 border border-red-500/20 rounded-lg p-4 mb-4">
               <p className="text-red-400 text-base">
@@ -239,9 +239,9 @@ export default function ApprovalRequestsTab() {
                 30日後にデータは完全に削除されます。
               </p>
             </div>
-            <div className="mb-4 p-3 bg-gray-700 rounded-lg">
-              <p className="text-base text-gray-400 mb-1">タイトル: {selectedRequest.title}</p>
-              <p className="text-gray-300">{selectedRequest.reason}</p>
+            <div className="mb-4 p-3 bg-slate-100 rounded-lg dark:bg-gray-700">
+              <p className="text-base text-slate-500 mb-1 dark:text-gray-400">タイトル: {selectedRequest.title}</p>
+              <p className="text-slate-700 dark:text-gray-300">{selectedRequest.reason}</p>
             </div>
             <div className="flex justify-end gap-2">
               <button
@@ -249,7 +249,7 @@ export default function ApprovalRequestsTab() {
                   setShowApproveConfirm(false);
                   setSelectedRequest(null);
                 }}
-                className="bg-gray-600 hover:bg-gray-500 text-white px-4 py-2 rounded-lg transition-colors"
+                className="bg-slate-200 hover:bg-slate-300 text-slate-900 px-4 py-2 rounded-lg transition-colors dark:bg-gray-600 dark:hover:bg-gray-500 dark:text-white"
               >
                 キャンセル
               </button>
@@ -268,21 +268,21 @@ export default function ApprovalRequestsTab() {
       {/* 却下モーダル */}
       {selectedRequest && !showApproveConfirm && (
         <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-50 p-4">
-          <div className="bg-gray-800 rounded-lg p-6 max-w-lg w-full">
-            <h3 className="text-2xl font-bold text-white mb-4">退会リクエストを却下</h3>
-            <div className="mb-4 p-3 bg-gray-700 rounded-lg">
-              <p className="text-base text-gray-400 mb-1">タイトル: {selectedRequest.title}</p>
-              <p className="text-gray-300">{selectedRequest.reason}</p>
+          <div className="bg-white rounded-lg p-6 max-w-lg w-full dark:bg-gray-800">
+            <h3 className="text-2xl font-bold text-slate-950 mb-4 dark:text-white">退会リクエストを却下</h3>
+            <div className="mb-4 p-3 bg-slate-100 rounded-lg dark:bg-gray-700">
+              <p className="text-base text-slate-500 mb-1 dark:text-gray-400">タイトル: {selectedRequest.title}</p>
+              <p className="text-slate-700 dark:text-gray-300">{selectedRequest.reason}</p>
             </div>
             <div className="mb-4">
-              <label className="block text-base text-gray-400 mb-2">
+              <label className="block text-base text-slate-600 mb-2 dark:text-gray-400">
                 却下理由 <span className="text-red-400">*</span>
               </label>
               <textarea
                 value={rejectReason}
                 onChange={(e) => setRejectReason(e.target.value)}
                 placeholder="却下理由を入力..."
-                className="w-full bg-gray-700 border border-gray-600 rounded-lg px-3 py-2 text-white placeholder-gray-500 h-32 resize-none"
+                className="w-full bg-white border border-slate-300 rounded-lg px-3 py-2 text-slate-900 placeholder-slate-400 h-32 resize-none dark:bg-gray-700 dark:border-gray-600 dark:text-white dark:placeholder-gray-500"
               />
             </div>
             <div className="flex justify-end gap-2">
@@ -291,7 +291,7 @@ export default function ApprovalRequestsTab() {
                   setSelectedRequest(null);
                   setRejectReason('');
                 }}
-                className="bg-gray-600 hover:bg-gray-500 text-white px-4 py-2 rounded-lg transition-colors"
+                className="bg-slate-200 hover:bg-slate-300 text-slate-900 px-4 py-2 rounded-lg transition-colors dark:bg-gray-600 dark:hover:bg-gray-500 dark:text-white"
               >
                 キャンセル
               </button>

--- a/components/protected/app-admin/tabs/AuditLogTab.tsx
+++ b/components/protected/app-admin/tabs/AuditLogTab.tsx
@@ -54,10 +54,10 @@ export default function AuditLogTab() {
   };
 
   const getActionColor = (action: string) => {
-    if (action.includes('approved')) return 'text-green-400';
-    if (action.includes('rejected') || action.includes('deleted') || action.includes('failed')) return 'text-red-400';
-    if (action.includes('created') || action.includes('enabled')) return 'text-blue-400';
-    return 'text-gray-300';
+    if (action.includes('approved')) return 'text-green-600 dark:text-green-400';
+    if (action.includes('rejected') || action.includes('deleted') || action.includes('failed')) return 'text-red-600 dark:text-red-400';
+    if (action.includes('created') || action.includes('enabled')) return 'text-blue-600 dark:text-blue-400';
+    return 'text-slate-700 dark:text-gray-300';
   };
 
   return (
@@ -67,7 +67,7 @@ export default function AuditLogTab() {
         <div className="flex gap-2">
           <button
             onClick={() => setShowFilters(!showFilters)}
-            className="flex items-center gap-2 bg-gray-700 hover:bg-gray-600 text-white px-4 py-2 rounded-lg transition-colors"
+            className="flex items-center gap-2 bg-slate-200 hover:bg-slate-300 text-slate-900 px-4 py-2 rounded-lg transition-colors dark:bg-gray-700 dark:hover:bg-gray-600 dark:text-white"
           >
             <FaFilter className="w-4 h-4" />
             フィルター
@@ -85,14 +85,14 @@ export default function AuditLogTab() {
 
       {/* フィルターパネル */}
       {showFilters && (
-        <div className="bg-gray-800 rounded-lg p-4 mb-6 border border-gray-700">
+        <div className="bg-white rounded-lg p-4 mb-6 border border-slate-300 dark:bg-gray-800 dark:border-gray-700">
           <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
             <div>
-              <label className="block text-base text-gray-400 mb-1">ターゲット種別</label>
+              <label className="block text-base text-slate-600 mb-1 dark:text-gray-400">ターゲット種別</label>
               <select
                 value={filters.target_type || ''}
                 onChange={(e) => setFilters({ ...filters, target_type: e.target.value || undefined })}
-                className="w-full bg-gray-700 border border-gray-600 rounded-lg px-3 py-2 text-white"
+                className="w-full bg-white border border-slate-300 rounded-lg px-3 py-2 text-slate-900 dark:bg-gray-700 dark:border-gray-600 dark:text-white"
               >
                 <option value="">すべて</option>
                 <option value="staff">スタッフ</option>
@@ -101,11 +101,11 @@ export default function AuditLogTab() {
               </select>
             </div>
             <div>
-              <label className="block text-base text-gray-400 mb-1">アクション</label>
+              <label className="block text-base text-slate-600 mb-1 dark:text-gray-400">アクション</label>
               <select
                 value={filters.action || ''}
                 onChange={(e) => setFilters({ ...filters, action: e.target.value || undefined })}
-                className="w-full bg-gray-700 border border-gray-600 rounded-lg px-3 py-2 text-white"
+                className="w-full bg-white border border-slate-300 rounded-lg px-3 py-2 text-slate-900 dark:bg-gray-700 dark:border-gray-600 dark:text-white"
               >
                 <option value="">すべて</option>
                 <option value="withdrawal.approved">退会承認</option>
@@ -117,12 +117,12 @@ export default function AuditLogTab() {
               </select>
             </div>
             <div>
-              <label className="block text-base text-gray-400 mb-1">開始日</label>
+              <label className="block text-base text-slate-600 mb-1 dark:text-gray-400">開始日</label>
               <input
                 type="date"
                 value={filters.start_date || ''}
                 onChange={(e) => setFilters({ ...filters, start_date: e.target.value || undefined })}
-                className="w-full bg-gray-700 border border-gray-600 rounded-lg px-3 py-2 text-white"
+                className="w-full bg-white border border-slate-300 rounded-lg px-3 py-2 text-slate-900 dark:bg-gray-700 dark:border-gray-600 dark:text-white"
               />
             </div>
           </div>
@@ -132,7 +132,7 @@ export default function AuditLogTab() {
                 setFilters({ limit: 30 });
                 setCurrentPage(0);
               }}
-              className="bg-gray-600 hover:bg-gray-500 text-white px-4 py-2 rounded-lg transition-colors"
+              className="bg-slate-200 hover:bg-slate-300 text-slate-900 px-4 py-2 rounded-lg transition-colors dark:bg-gray-600 dark:hover:bg-gray-500 dark:text-white"
             >
               リセット
             </button>
@@ -154,51 +154,51 @@ export default function AuditLogTab() {
       )}
 
       {/* ログテーブル */}
-      <div className="bg-gray-800 rounded-lg border border-gray-700 overflow-hidden">
+      <div className="bg-white rounded-lg border border-slate-300 overflow-hidden dark:bg-gray-800 dark:border-gray-700">
         {isLoading ? (
           <div className="p-8 text-center">
             <div className="animate-spin rounded-full h-8 w-8 border-t-2 border-b-2 border-purple-400 mx-auto"></div>
-            <p className="text-gray-400 mt-4">読み込み中...</p>
+            <p className="text-slate-600 mt-4 dark:text-gray-400">読み込み中...</p>
           </div>
         ) : logs.length === 0 ? (
           <div className="p-8 text-center">
-            <p className="text-gray-400">監査ログがありません</p>
+            <p className="text-slate-600 dark:text-gray-400">監査ログがありません</p>
           </div>
         ) : (
           <div className="overflow-x-auto">
             <table className="w-full">
-              <thead className="bg-gray-700">
+              <thead className="bg-slate-100 dark:bg-gray-700">
                 <tr>
-                  <th className="text-left py-3 px-4 text-gray-300 font-semibold">日時</th>
-                  <th className="text-left py-3 px-4 text-gray-300 font-semibold">実行者</th>
-                  <th className="text-left py-3 px-4 text-gray-300 font-semibold">アクション</th>
-                  <th className="text-left py-3 px-4 text-gray-300 font-semibold">対象</th>
-                  <th className="text-left py-3 px-4 text-gray-300 font-semibold">事務所</th>
-                  <th className="text-left py-3 px-4 text-gray-300 font-semibold">詳細</th>
+                  <th className="text-left py-3 px-4 text-slate-700 font-semibold dark:text-gray-300">日時</th>
+                  <th className="text-left py-3 px-4 text-slate-700 font-semibold dark:text-gray-300">実行者</th>
+                  <th className="text-left py-3 px-4 text-slate-700 font-semibold dark:text-gray-300">アクション</th>
+                  <th className="text-left py-3 px-4 text-slate-700 font-semibold dark:text-gray-300">対象</th>
+                  <th className="text-left py-3 px-4 text-slate-700 font-semibold dark:text-gray-300">事務所</th>
+                  <th className="text-left py-3 px-4 text-slate-700 font-semibold dark:text-gray-300">詳細</th>
                 </tr>
               </thead>
               <tbody>
                 {logs.map((log) => (
-                  <tr key={log.id} className="border-t border-gray-700 hover:bg-gray-700/50">
-                    <td className="py-3 px-4 text-gray-300 text-base whitespace-nowrap">
+                  <tr key={log.id} className="border-t border-slate-200 hover:bg-slate-50 dark:border-gray-700 dark:hover:bg-gray-700/50">
+                    <td className="py-3 px-4 text-slate-700 text-base whitespace-nowrap dark:text-gray-300">
                       {formatDate(log.created_at)}
                     </td>
                     <td className="py-3 px-4">
                       <div>
-                        <p className="text-white">{log.actor_name}</p>
-                        <p className="text-base text-gray-400">{log.actor_role}</p>
+                        <p className="text-slate-950 dark:text-white">{log.actor_name}</p>
+                        <p className="text-base text-slate-500 dark:text-gray-400">{log.actor_role}</p>
                       </div>
                     </td>
                     <td className={`py-3 px-4 font-mono text-base ${getActionColor(log.action)}`}>
                       {log.action}
                     </td>
-                    <td className="py-3 px-4 text-gray-300 text-base">
+                    <td className="py-3 px-4 text-slate-700 text-base dark:text-gray-300">
                       {log.target_type}
                     </td>
-                    <td className="py-3 px-4 text-gray-300 text-base">
+                    <td className="py-3 px-4 text-slate-700 text-base dark:text-gray-300">
                       {log.office_name || '-'}
                     </td>
-                    <td className="py-3 px-4 text-gray-400 text-base max-w-xs truncate">
+                    <td className="py-3 px-4 text-slate-500 text-base max-w-xs truncate dark:text-gray-400">
                       {JSON.stringify(log.details)}
                     </td>
                   </tr>
@@ -212,24 +212,24 @@ export default function AuditLogTab() {
       {/* ページネーション */}
       {totalPages > 1 && (
         <div className="flex items-center justify-between mt-4">
-          <p className="text-gray-400 text-base">
+          <p className="text-slate-600 text-base dark:text-gray-400">
             全 {total} 件中 {currentPage * ITEMS_PER_PAGE + 1} - {Math.min((currentPage + 1) * ITEMS_PER_PAGE, total)} 件を表示
           </p>
           <div className="flex gap-2">
             <button
               onClick={() => setCurrentPage(currentPage - 1)}
               disabled={currentPage === 0}
-              className="bg-gray-700 hover:bg-gray-600 text-white px-4 py-2 rounded-lg transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+              className="bg-slate-200 hover:bg-slate-300 text-slate-900 px-4 py-2 rounded-lg transition-colors disabled:opacity-50 disabled:cursor-not-allowed dark:bg-gray-700 dark:hover:bg-gray-600 dark:text-white"
             >
               前へ
             </button>
-            <span className="bg-gray-700 text-white px-4 py-2 rounded-lg">
+            <span className="bg-slate-200 text-slate-900 px-4 py-2 rounded-lg dark:bg-gray-700 dark:text-white">
               {currentPage + 1} / {totalPages}
             </span>
             <button
               onClick={() => setCurrentPage(currentPage + 1)}
               disabled={currentPage >= totalPages - 1}
-              className="bg-gray-700 hover:bg-gray-600 text-white px-4 py-2 rounded-lg transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+              className="bg-slate-200 hover:bg-slate-300 text-slate-900 px-4 py-2 rounded-lg transition-colors disabled:opacity-50 disabled:cursor-not-allowed dark:bg-gray-700 dark:hover:bg-gray-600 dark:text-white"
             >
               次へ
             </button>

--- a/components/protected/app-admin/tabs/InquiriesTab.tsx
+++ b/components/protected/app-admin/tabs/InquiriesTab.tsx
@@ -83,7 +83,7 @@ export default function InquiriesTab() {
               setStatusFilter(e.target.value as typeof statusFilter);
               setCurrentPage(0);
             }}
-            className="bg-gray-700 border border-gray-600 rounded-lg px-3 py-2 text-white"
+            className="bg-white border border-slate-300 rounded-lg px-3 py-2 text-slate-900 dark:bg-gray-700 dark:border-gray-600 dark:text-white"
           >
             <option value="">すべて</option>
             <option value="new">新規</option>
@@ -110,39 +110,39 @@ export default function InquiriesTab() {
         </div>
       )}
 
-      <div className="bg-gray-800 rounded-lg border border-gray-700">
+      <div className="bg-white rounded-lg border border-slate-300 dark:bg-gray-800 dark:border-gray-700">
         {isLoading ? (
           <div className="p-8 text-center">
             <div className="animate-spin rounded-full h-8 w-8 border-t-2 border-b-2 border-purple-400 mx-auto"></div>
-            <p className="text-gray-400 mt-4">読み込み中...</p>
+            <p className="text-slate-600 mt-4 dark:text-gray-400">読み込み中...</p>
           </div>
         ) : inquiries.length === 0 ? (
           <div className="p-8 text-center">
-            <p className="text-gray-400">問い合わせがありません</p>
+            <p className="text-slate-600 dark:text-gray-400">問い合わせがありません</p>
           </div>
         ) : (
-          <div className="divide-y divide-gray-700">
+          <div className="divide-y divide-slate-200 dark:divide-gray-700">
             {inquiries.map((inquiry) => (
-              <div key={inquiry.id} className="p-4 hover:bg-gray-700/50">
+              <div key={inquiry.id} className="p-4 hover:bg-slate-50 dark:hover:bg-gray-700/50">
                 <div className="flex items-start justify-between">
                   <div className="flex-1">
                     <div className="flex items-center gap-2 mb-2">
                       {inquiry.status === 'new' ? (
                         <FaEnvelope className="w-4 h-4 text-red-400" />
                       ) : (
-                        <FaEnvelopeOpen className="w-4 h-4 text-gray-400" />
+                        <FaEnvelopeOpen className="w-4 h-4 text-slate-400 dark:text-gray-400" />
                       )}
-                      <span className="font-semibold text-white">{inquiry.title}</span>
+                      <span className="font-semibold text-slate-950 dark:text-white">{inquiry.title}</span>
                       {getStatusBadge(inquiry.status)}
                     </div>
-                    <p className="text-gray-300 text-base mb-2 line-clamp-2">{inquiry.content}</p>
-                    <div className="flex items-center gap-4 text-base text-gray-400 mb-2">
+                    <p className="text-slate-700 text-base mb-2 line-clamp-2 dark:text-gray-300">{inquiry.content}</p>
+                    <div className="flex items-center gap-4 text-base text-slate-500 mb-2 dark:text-gray-400">
                       <span>送信者: {inquiry.sender_name || '未設定'}</span>
                       {inquiry.sender_email && <span>{inquiry.sender_email}</span>}
                       <span>{formatDate(inquiry.created_at)}</span>
                     </div>
                     {inquiry.assigned_staff && (
-                      <div className="text-base text-gray-400 mb-2">
+                      <div className="text-base text-slate-500 mb-2 dark:text-gray-400">
                         <span>担当者: {inquiry.assigned_staff.last_name} {inquiry.assigned_staff.first_name}</span>
                       </div>
                     )}
@@ -150,14 +150,14 @@ export default function InquiriesTab() {
                   <div className="flex gap-2 ml-4">
                     <button
                       onClick={() => setReplyInquiry(inquiry)}
-                      className="text-green-400 hover:text-green-300 p-2 rounded-lg hover:bg-gray-600 transition-colors"
+                      className="text-green-600 hover:text-green-700 p-2 rounded-lg hover:bg-slate-100 transition-colors dark:text-green-400 dark:hover:text-green-300 dark:hover:bg-gray-600"
                       title="返信する"
                     >
                       <FaReply className="w-4 h-4" />
                     </button>
                     <button
                       onClick={() => setSelectedInquiry(inquiry)}
-                      className="text-purple-400 hover:text-purple-300 p-2 rounded-lg hover:bg-gray-600 transition-colors"
+                      className="text-purple-600 hover:text-purple-700 p-2 rounded-lg hover:bg-slate-100 transition-colors dark:text-purple-400 dark:hover:text-purple-300 dark:hover:bg-gray-600"
                       title="詳細を見る"
                     >
                       <FaEye className="w-4 h-4" />
@@ -173,21 +173,21 @@ export default function InquiriesTab() {
       {/* ページネーション */}
       {totalPages > 1 && (
         <div className="flex items-center justify-between mt-4">
-          <p className="text-gray-400 text-base">
+          <p className="text-slate-600 text-base dark:text-gray-400">
             全 {total} 件中 {currentPage * ITEMS_PER_PAGE + 1} - {Math.min((currentPage + 1) * ITEMS_PER_PAGE, total)} 件を表示
           </p>
           <div className="flex gap-2">
             <button
               onClick={() => setCurrentPage(currentPage - 1)}
               disabled={currentPage === 0}
-              className="bg-gray-700 hover:bg-gray-600 text-white px-4 py-2 rounded-lg transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+              className="bg-slate-200 hover:bg-slate-300 text-slate-900 px-4 py-2 rounded-lg transition-colors disabled:opacity-50 disabled:cursor-not-allowed dark:bg-gray-700 dark:hover:bg-gray-600 dark:text-white"
             >
               前へ
             </button>
             <button
               onClick={() => setCurrentPage(currentPage + 1)}
               disabled={currentPage >= totalPages - 1}
-              className="bg-gray-700 hover:bg-gray-600 text-white px-4 py-2 rounded-lg transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+              className="bg-slate-200 hover:bg-slate-300 text-slate-900 px-4 py-2 rounded-lg transition-colors disabled:opacity-50 disabled:cursor-not-allowed dark:bg-gray-700 dark:hover:bg-gray-600 dark:text-white"
             >
               次へ
             </button>
@@ -198,28 +198,28 @@ export default function InquiriesTab() {
       {/* 詳細モーダル */}
       {selectedInquiry && (
         <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-50 p-4">
-          <div className="bg-gray-800 rounded-lg p-6 max-w-2xl w-full max-h-[90vh] overflow-y-auto">
-            <h3 className="text-2xl font-bold text-white mb-4">問い合わせ詳細</h3>
+          <div className="bg-white rounded-lg p-6 max-w-2xl w-full max-h-[90vh] overflow-y-auto dark:bg-gray-800">
+            <h3 className="text-2xl font-bold text-slate-950 mb-4 dark:text-white">問い合わせ詳細</h3>
 
             <div className="space-y-4">
               {/* 基本情報 */}
-              <div className="bg-gray-700 rounded-lg p-4">
-                <h4 className="text-base font-semibold text-gray-300 mb-3">基本情報</h4>
+              <div className="bg-slate-100 rounded-lg p-4 dark:bg-gray-700">
+                <h4 className="text-base font-semibold text-slate-700 mb-3 dark:text-gray-300">基本情報</h4>
                 <div className="space-y-2">
                   <div className="flex items-center gap-2">
-                    <span className="text-base text-gray-400 w-24">件名:</span>
-                    <span className="text-white">{selectedInquiry.title}</span>
+                    <span className="text-base text-slate-500 w-24 dark:text-gray-400">件名:</span>
+                    <span className="text-slate-950 dark:text-white">{selectedInquiry.title}</span>
                   </div>
                   <div className="flex items-start gap-2">
-                    <span className="text-base text-gray-400 w-24 flex-shrink-0">内容:</span>
-                    <p className="text-white whitespace-pre-wrap flex-1">{selectedInquiry.content}</p>
+                    <span className="text-base text-slate-500 w-24 flex-shrink-0 dark:text-gray-400">内容:</span>
+                    <p className="text-slate-950 whitespace-pre-wrap flex-1 dark:text-white">{selectedInquiry.content}</p>
                   </div>
                   <div className="flex items-center gap-2">
-                    <span className="text-base text-gray-400 w-24">ステータス:</span>
+                    <span className="text-base text-slate-500 w-24 dark:text-gray-400">ステータス:</span>
                     {getStatusBadge(selectedInquiry.status)}
                   </div>
                   <div className="flex items-center gap-2">
-                    <span className="text-base text-gray-400 w-24">優先度:</span>
+                    <span className="text-base text-slate-500 w-24 dark:text-gray-400">優先度:</span>
                     <span className={`px-2 py-1 rounded text-base ${
                       selectedInquiry.priority === 'high' ? 'bg-red-500/20 text-red-400' :
                       selectedInquiry.priority === 'low' ? 'bg-gray-500/20 text-gray-400' :
@@ -230,24 +230,24 @@ export default function InquiriesTab() {
                     </span>
                   </div>
                   <div className="flex items-center gap-2">
-                    <span className="text-base text-gray-400 w-24">作成日時:</span>
-                    <span className="text-white text-base">{formatDate(selectedInquiry.created_at)}</span>
+                    <span className="text-base text-slate-500 w-24 dark:text-gray-400">作成日時:</span>
+                    <span className="text-slate-950 text-base dark:text-white">{formatDate(selectedInquiry.created_at)}</span>
                   </div>
                 </div>
               </div>
 
               {/* 送信者情報 */}
-              <div className="bg-gray-700 rounded-lg p-4">
-                <h4 className="text-base font-semibold text-gray-300 mb-3">送信者情報</h4>
+              <div className="bg-slate-100 rounded-lg p-4 dark:bg-gray-700">
+                <h4 className="text-base font-semibold text-slate-700 mb-3 dark:text-gray-300">送信者情報</h4>
                 <div className="space-y-2">
                   <div className="flex items-center gap-2">
-                    <span className="text-base text-gray-400 w-24">名前:</span>
-                    <span className="text-white">{selectedInquiry.sender_name || '未設定'}</span>
+                    <span className="text-base text-slate-500 w-24 dark:text-gray-400">名前:</span>
+                    <span className="text-slate-950 dark:text-white">{selectedInquiry.sender_name || '未設定'}</span>
                   </div>
                   {selectedInquiry.sender_email && (
                     <div className="flex items-center gap-2">
-                      <span className="text-base text-gray-400 w-24">メール:</span>
-                      <span className="text-white">{selectedInquiry.sender_email}</span>
+                      <span className="text-base text-slate-500 w-24 dark:text-gray-400">メール:</span>
+                      <span className="text-slate-950 dark:text-white">{selectedInquiry.sender_email}</span>
                     </div>
                   )}
                 </div>
@@ -255,18 +255,18 @@ export default function InquiriesTab() {
 
               {/* 担当者情報 */}
               {selectedInquiry.assigned_staff && (
-                <div className="bg-gray-700 rounded-lg p-4">
-                  <h4 className="text-base font-semibold text-gray-300 mb-3">担当者</h4>
+                <div className="bg-slate-100 rounded-lg p-4 dark:bg-gray-700">
+                  <h4 className="text-base font-semibold text-slate-700 mb-3 dark:text-gray-300">担当者</h4>
                   <div className="space-y-2">
                     <div className="flex items-center gap-2">
-                      <span className="text-base text-gray-400 w-24">担当者:</span>
-                      <span className="text-white">
+                      <span className="text-base text-slate-500 w-24 dark:text-gray-400">担当者:</span>
+                      <span className="text-slate-950 dark:text-white">
                         {selectedInquiry.assigned_staff.last_name} {selectedInquiry.assigned_staff.first_name}
                       </span>
                     </div>
                     <div className="flex items-center gap-2">
-                      <span className="text-base text-gray-400 w-24">メール:</span>
-                      <span className="text-white">{selectedInquiry.assigned_staff.email}</span>
+                      <span className="text-base text-slate-500 w-24 dark:text-gray-400">メール:</span>
+                      <span className="text-slate-950 dark:text-white">{selectedInquiry.assigned_staff.email}</span>
                     </div>
                   </div>
                 </div>
@@ -285,7 +285,7 @@ export default function InquiriesTab() {
               </button>
               <button
                 onClick={() => setSelectedInquiry(null)}
-                className="bg-gray-600 hover:bg-gray-500 text-white px-4 py-2 rounded-lg transition-colors"
+                className="bg-slate-200 hover:bg-slate-300 text-slate-900 px-4 py-2 rounded-lg transition-colors dark:bg-gray-600 dark:hover:bg-gray-500 dark:text-white"
               >
                 閉じる
               </button>

--- a/components/protected/app-admin/tabs/NewInquiriesTab.tsx
+++ b/components/protected/app-admin/tabs/NewInquiriesTab.tsx
@@ -4,6 +4,8 @@ import { useState } from 'react';
 import InquiryList from '@/components/admin/inquiry/InquiryList';
 import InquiryDetail from '@/components/admin/inquiry/InquiryDetail';
 import InquiryReplyModal from '@/components/admin/inquiry/InquiryReplyModal';
+import type { InquiryFullResponse } from '@/types/inquiry';
+import { getReplyInquiryInfo, type ReplyInquiryInfo } from './newInquiriesTab.helpers';
 
 type ViewMode = 'list' | 'detail';
 
@@ -11,7 +13,7 @@ export default function NewInquiriesTab() {
   const [viewMode, setViewMode] = useState<ViewMode>('list');
   const [selectedInquiryId, setSelectedInquiryId] = useState<string | null>(null);
   const [isReplyModalOpen, setIsReplyModalOpen] = useState(false);
-  const [replyInquiryId, setReplyInquiryId] = useState<string | null>(null);
+  const [replyInquiry, setReplyInquiry] = useState<ReplyInquiryInfo | null>(null);
 
   const handleSelectInquiry = (inquiryId: string) => {
     setSelectedInquiryId(inquiryId);
@@ -23,14 +25,14 @@ export default function NewInquiriesTab() {
     setViewMode('list');
   };
 
-  const handleOpenReply = (inquiryId: string) => {
-    setReplyInquiryId(inquiryId);
+  const handleOpenReply = (inquiry: InquiryFullResponse) => {
+    setReplyInquiry(getReplyInquiryInfo(inquiry));
     setIsReplyModalOpen(true);
   };
 
   const handleCloseReply = () => {
     setIsReplyModalOpen(false);
-    setReplyInquiryId(null);
+    setReplyInquiry(null);
   };
 
   const handleReplySuccess = () => {
@@ -56,13 +58,13 @@ export default function NewInquiriesTab() {
       )}
 
       {/* 返信モーダル */}
-      {isReplyModalOpen && replyInquiryId && (
+      {isReplyModalOpen && replyInquiry && (
         <InquiryReplyModal
           isOpen={isReplyModalOpen}
           onClose={handleCloseReply}
-          inquiryId={replyInquiryId}
-          inquiryTitle="問い合わせ件名" // TODO: 実際の件名を渡す
-          senderEmail="example@example.com" // TODO: 実際の送信者メールを渡す
+          inquiryId={replyInquiry.inquiryId}
+          inquiryTitle={replyInquiry.inquiryTitle}
+          senderEmail={replyInquiry.senderEmail}
           onSuccess={handleReplySuccess}
         />
       )}

--- a/components/protected/app-admin/tabs/OfficesTab.tsx
+++ b/components/protected/app-admin/tabs/OfficesTab.tsx
@@ -79,7 +79,7 @@ export default function OfficesTab() {
               value={searchQuery}
               onChange={(e) => setSearchQuery(e.target.value)}
               placeholder="事務所名で検索..."
-              className="bg-gray-700 border border-gray-600 rounded-lg pl-10 pr-4 py-2 text-white placeholder-gray-500 w-64"
+              className="bg-white border border-slate-300 rounded-lg pl-10 pr-4 py-2 text-slate-900 placeholder-slate-400 w-64 dark:bg-gray-700 dark:border-gray-600 dark:text-white dark:placeholder-gray-500"
             />
           </div>
           <button
@@ -99,29 +99,29 @@ export default function OfficesTab() {
         </div>
       )}
 
-      <div className="bg-gray-800 rounded-lg border border-gray-700 overflow-hidden">
+      <div className="bg-white rounded-lg border border-slate-300 overflow-hidden dark:bg-gray-800 dark:border-gray-700">
         {isLoading ? (
           <div className="p-8 text-center">
             <div className="animate-spin rounded-full h-8 w-8 border-t-2 border-b-2 border-purple-400 mx-auto"></div>
-            <p className="text-gray-400 mt-4">読み込み中...</p>
+            <p className="text-slate-600 mt-4 dark:text-gray-400">読み込み中...</p>
           </div>
         ) : offices.length === 0 ? (
           <div className="p-8 text-center">
-            <p className="text-gray-400">
+            <p className="text-slate-600 dark:text-gray-400">
               {debouncedSearch ? `「${debouncedSearch}」に一致する事務所が見つかりません` : '事務所がありません'}
             </p>
           </div>
         ) : (
           <div className="overflow-x-auto">
             <table className="w-full">
-              <thead className="bg-gray-700">
+              <thead className="bg-slate-100 dark:bg-gray-700">
                 <tr>
-                  <th className="text-left py-3 px-4 text-gray-300 font-semibold">事務所名</th>
-                  <th className="text-left py-3 px-4 text-gray-300 font-semibold">種別</th>
-                  <th className="text-left py-3 px-4 text-gray-300 font-semibold">住所</th>
-                  <th className="text-left py-3 px-4 text-gray-300 font-semibold">電話番号</th>
-                  <th className="text-left py-3 px-4 text-gray-300 font-semibold">メール</th>
-                  <th className="text-left py-3 px-4 text-gray-300 font-semibold"></th>
+                  <th className="text-left py-3 px-4 text-slate-700 font-semibold dark:text-gray-300">事務所名</th>
+                  <th className="text-left py-3 px-4 text-slate-700 font-semibold dark:text-gray-300">種別</th>
+                  <th className="text-left py-3 px-4 text-slate-700 font-semibold dark:text-gray-300">住所</th>
+                  <th className="text-left py-3 px-4 text-slate-700 font-semibold dark:text-gray-300">電話番号</th>
+                  <th className="text-left py-3 px-4 text-slate-700 font-semibold dark:text-gray-300">メール</th>
+                  <th className="text-left py-3 px-4 text-slate-700 font-semibold dark:text-gray-300"></th>
                 </tr>
               </thead>
               <tbody>
@@ -129,30 +129,30 @@ export default function OfficesTab() {
                   <tr
                     key={office.id}
                     onClick={() => handleOfficeClick(office.id)}
-                    className="border-t border-gray-700 hover:bg-gray-700/50 cursor-pointer transition-colors"
+                    className="border-t border-slate-200 hover:bg-slate-50 cursor-pointer transition-colors dark:border-gray-700 dark:hover:bg-gray-700/50"
                   >
                     <td className="py-3 px-4">
                       <div className="flex items-center gap-2">
                         <FaBuilding className="w-4 h-4 text-purple-400" />
-                        <span className="text-white font-semibold">{office.name}</span>
+                        <span className="text-slate-950 font-semibold dark:text-white">{office.name}</span>
                       </div>
                     </td>
                     <td className="py-3 px-4">
-                      <span className="bg-gray-600 text-gray-200 px-2 py-1 rounded text-base">
+                      <span className="bg-slate-200 text-slate-700 px-2 py-1 rounded text-base dark:bg-gray-600 dark:text-gray-200">
                         {getOfficeTypeName(office.office_type)}
                       </span>
                     </td>
-                    <td className="py-3 px-4 text-gray-300 text-base">
+                    <td className="py-3 px-4 text-slate-700 text-base dark:text-gray-300">
                       {office.address || '-'}
                     </td>
-                    <td className="py-3 px-4 text-gray-300 text-base">
+                    <td className="py-3 px-4 text-slate-700 text-base dark:text-gray-300">
                       {office.phone_number || '-'}
                     </td>
-                    <td className="py-3 px-4 text-gray-300 text-base">
+                    <td className="py-3 px-4 text-slate-700 text-base dark:text-gray-300">
                       {office.email || '-'}
                     </td>
                     <td className="py-3 px-4">
-                      <FaChevronRight className="w-4 h-4 text-gray-400" />
+                      <FaChevronRight className="w-4 h-4 text-slate-400 dark:text-gray-400" />
                     </td>
                   </tr>
                 ))}
@@ -165,24 +165,24 @@ export default function OfficesTab() {
       {/* ページネーション */}
       {(currentPage > 0 || hasNextPage) && (
         <div className="flex items-center justify-between mt-4">
-          <p className="text-gray-400 text-base">
+          <p className="text-slate-600 text-base dark:text-gray-400">
             {offices.length} 件を表示中（ページ {currentPage + 1}）
           </p>
           <div className="flex gap-2">
             <button
               onClick={() => setCurrentPage(currentPage - 1)}
               disabled={currentPage === 0}
-              className="bg-gray-700 hover:bg-gray-600 text-white px-4 py-2 rounded-lg transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+              className="bg-slate-200 hover:bg-slate-300 text-slate-900 px-4 py-2 rounded-lg transition-colors disabled:opacity-50 disabled:cursor-not-allowed dark:bg-gray-700 dark:hover:bg-gray-600 dark:text-white"
             >
               前へ
             </button>
-            <span className="bg-gray-700 text-white px-4 py-2 rounded-lg">
+            <span className="bg-slate-200 text-slate-900 px-4 py-2 rounded-lg dark:bg-gray-700 dark:text-white">
               ページ {currentPage + 1}
             </span>
             <button
               onClick={() => setCurrentPage(currentPage + 1)}
               disabled={!hasNextPage}
-              className="bg-gray-700 hover:bg-gray-600 text-white px-4 py-2 rounded-lg transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+              className="bg-slate-200 hover:bg-slate-300 text-slate-900 px-4 py-2 rounded-lg transition-colors disabled:opacity-50 disabled:cursor-not-allowed dark:bg-gray-700 dark:hover:bg-gray-600 dark:text-white"
             >
               次へ
             </button>

--- a/components/protected/app-admin/tabs/newInquiriesTab.helpers.test.ts
+++ b/components/protected/app-admin/tabs/newInquiriesTab.helpers.test.ts
@@ -1,0 +1,56 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import type { InquiryFullResponse } from '../../../../types/inquiry';
+import { getReplyInquiryInfo } from './newInquiriesTab.helpers';
+
+function buildInquiry(overrides: Partial<InquiryFullResponse> = {}): InquiryFullResponse {
+  return {
+    id: 'inquiry-1',
+    message: {
+      id: 'message-1',
+      title: '実際の問い合わせ件名',
+      content: '問い合わせ本文',
+      created_at: '2026-07-02T00:00:00Z',
+    },
+    inquiry_detail: {
+      id: 'detail-1',
+      sender_name: '問い合わせ 太郎',
+      sender_email: 'sender@example.com',
+      ip_address: null,
+      user_agent: null,
+      status: 'new',
+      priority: 'normal',
+      assigned_staff_id: null,
+      admin_notes: null,
+      delivery_log: null,
+      created_at: '2026-07-02T00:00:00Z',
+      updated_at: '2026-07-02T00:00:00Z',
+    },
+    assigned_staff: null,
+    reply_history: null,
+    ...overrides,
+  };
+}
+
+test('getReplyInquiryInfo passes actual inquiry title and sender email to reply modal', () => {
+  assert.deepEqual(getReplyInquiryInfo(buildInquiry()), {
+    inquiryId: 'inquiry-1',
+    inquiryTitle: '実際の問い合わせ件名',
+    senderEmail: 'sender@example.com',
+  });
+});
+
+test('getReplyInquiryInfo keeps senderEmail null when inquiry has no email', () => {
+  const inquiry = buildInquiry({
+    inquiry_detail: {
+      ...buildInquiry().inquiry_detail,
+      sender_email: null,
+    },
+  });
+
+  assert.deepEqual(getReplyInquiryInfo(inquiry), {
+    inquiryId: 'inquiry-1',
+    inquiryTitle: '実際の問い合わせ件名',
+    senderEmail: null,
+  });
+});

--- a/components/protected/app-admin/tabs/newInquiriesTab.helpers.ts
+++ b/components/protected/app-admin/tabs/newInquiriesTab.helpers.ts
@@ -1,0 +1,15 @@
+import type { InquiryFullResponse } from '../../../../types/inquiry';
+
+export interface ReplyInquiryInfo {
+  inquiryId: string;
+  inquiryTitle: string;
+  senderEmail: string | null;
+}
+
+export function getReplyInquiryInfo(inquiry: InquiryFullResponse): ReplyInquiryInfo {
+  return {
+    inquiryId: inquiry.id,
+    inquiryTitle: inquiry.message.title,
+    senderEmail: inquiry.inquiry_detail.sender_email,
+  };
+}

--- a/components/protected/profile/FeedbackForm.tsx
+++ b/components/protected/profile/FeedbackForm.tsx
@@ -1,0 +1,127 @@
+'use client';
+
+import { useState } from 'react';
+import { toast } from '@/lib/toast-debug';
+import { inquiryApi } from '@/lib/api/inquiry';
+import type { InquiryCategory } from '@/types/inquiry';
+
+export default function FeedbackForm() {
+  const [feedbackContent, setFeedbackContent] = useState('');
+  const [feedbackTitle, setFeedbackTitle] = useState('');
+  const [feedbackCategory, setFeedbackCategory] = useState<InquiryCategory>('その他');
+  const [isSubmitting, setIsSubmitting] = useState(false);
+
+  const handleFeedbackSubmit = async () => {
+    if (!feedbackTitle.trim()) {
+      toast.error('件名を入力してください');
+      return;
+    }
+
+    if (!feedbackContent.trim()) {
+      toast.error('フィードバック内容を入力してください');
+      return;
+    }
+
+    setIsSubmitting(true);
+
+    try {
+      const response = await inquiryApi.createInquiry({
+        title: feedbackTitle,
+        content: feedbackContent,
+        category: feedbackCategory,
+      });
+
+      toast.success(response.message || 'フィードバックを送信しました。ご協力ありがとうございます。');
+      setFeedbackTitle('');
+      setFeedbackContent('');
+      setFeedbackCategory('その他');
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      toast.error(message || 'フィードバックの送信に失敗しました。しばらく時間をおいてからお試しください。');
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  return (
+    <div className="max-w-3xl mx-auto">
+      <h2 className="text-3xl font-bold mb-7">不具合・ご要望</h2>
+
+      <div className="bg-white border border-slate-300 shadow-sm dark:bg-[#1a1a2e] dark:border-[#2a2a3e] rounded-xl p-6">
+        <div className="mb-7 bg-blue-50 border border-blue-200 dark:bg-blue-900/20 dark:border-blue-700/30 rounded-lg p-5">
+          <div className="flex items-start gap-3">
+            <svg className="w-6 h-6 text-blue-400 mt-0.5 flex-shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
+            </svg>
+            <div>
+              <h3 className="text-blue-800 dark:text-blue-300 font-semibold mb-2">アプリ運営者へのフィードバック</h3>
+              <p className="text-blue-700 dark:text-blue-200 text-base leading-relaxed">
+                このフォームは、アプリの運営者に直接フィードバックを送信するためのものです。<br />
+                ご意見・ご要望・不具合報告など、お気軽にお送りください。
+              </p>
+            </div>
+          </div>
+        </div>
+
+        <div className="space-y-6">
+          <div>
+            <label className="text-slate-600 dark:text-gray-400 text-base block mb-2">カテゴリ</label>
+            <select
+              value={feedbackCategory}
+              onChange={(e) => setFeedbackCategory(e.target.value as InquiryCategory)}
+              className="w-full bg-white border border-slate-300 rounded-lg px-5 py-3 text-lg text-slate-900 dark:bg-[#0f1419] dark:border-[#2a2a3e] dark:text-white focus:outline-none focus:border-blue-500"
+            >
+              <option value="不具合">不具合報告</option>
+              <option value="質問">質問</option>
+              <option value="その他">その他（ご意見・ご要望）</option>
+            </select>
+          </div>
+
+          <div>
+            <label className="text-slate-600 dark:text-gray-400 text-base block mb-2">
+              件名 <span className="text-red-400">*</span>
+            </label>
+            <input
+              type="text"
+              value={feedbackTitle}
+              onChange={(e) => setFeedbackTitle(e.target.value)}
+              placeholder="例: ログイン画面で不具合があります"
+              maxLength={200}
+              className="w-full bg-white border border-slate-300 rounded-lg px-5 py-3 text-lg text-slate-900 dark:bg-[#0f1419] dark:border-[#2a2a3e] dark:text-white placeholder-slate-500 dark:placeholder-[#666] focus:outline-none focus:border-blue-500"
+            />
+            <p className="text-slate-500 dark:text-gray-500 text-base mt-1">
+              {feedbackTitle.length} / 200文字
+            </p>
+          </div>
+
+          <div>
+            <label className="text-slate-600 dark:text-gray-400 text-base block mb-2">
+              内容 <span className="text-red-400">*</span>
+            </label>
+            <textarea
+              rows={8}
+              value={feedbackContent}
+              onChange={(e) => setFeedbackContent(e.target.value)}
+              placeholder="フィードバック内容を入力してください...&#10;&#10;【不具合報告の場合】&#10;・発生した状況&#10;・エラーメッセージ&#10;・再現手順&#10;などを記載いただけると助かります。"
+              maxLength={20000}
+              className="w-full bg-white border border-slate-300 rounded-lg px-5 py-4 text-lg text-slate-900 dark:bg-[#0f1419] dark:border-[#2a2a3e] dark:text-white placeholder-slate-500 dark:placeholder-[#666] focus:outline-none focus:border-blue-500 resize-none"
+            />
+            <p className="text-slate-500 dark:text-gray-500 text-base mt-1">
+              {feedbackContent.length} / 20,000文字
+            </p>
+          </div>
+
+          <div className="flex gap-3">
+            <button
+              onClick={handleFeedbackSubmit}
+              disabled={isSubmitting || !feedbackTitle.trim() || !feedbackContent.trim()}
+              className="bg-blue-600 hover:bg-blue-700 text-white px-7 py-3 rounded-lg font-semibold disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
+            >
+              {isSubmitting ? '送信中...' : '運営者に送信'}
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/components/protected/profile/Profile.tsx
+++ b/components/protected/profile/Profile.tsx
@@ -8,12 +8,11 @@ import { profileApi } from '@/lib/profile';
 import { StaffNameUpdate, PasswordChange, EmailChangeRequest } from '@/types/profile';
 import { StaffRole } from '@/types/enums';
 import RoleChangeModal from './RoleChangeModal';
-import { inquiryApi } from '@/lib/api/inquiry';
-import type { InquiryCategory } from '@/types/inquiry';
 import { officeApi } from '@/lib/auth';
 import { OfficeResponse } from '@/types/office';
 import { getOfficeTypeLabel } from '@/lib/office-utils';
 import NotificationSettings from './NotificationSettings';
+import FeedbackForm from './FeedbackForm';
 
 interface ProfileProps {
   staff: StaffResponse | null;
@@ -46,7 +45,7 @@ export default function Profile({ staff: initialStaff }: ProfileProps) {
       try {
         const officeData = await officeApi.getMyOffice();
         setOffice(officeData);
-      } catch (error) {
+      } catch {
         console.error('Client operation failed');
       }
     };
@@ -77,11 +76,6 @@ export default function Profile({ staff: initialStaff }: ProfileProps) {
 
   // 権限説明ポップオーバー用のstate
   const [isRoleHelpOpen, setIsRoleHelpOpen] = useState<boolean>(false);
-
-  // フィードバック用のstate
-  const [feedbackContent, setFeedbackContent] = useState<string>('');
-  const [feedbackTitle, setFeedbackTitle] = useState<string>('');
-  const [feedbackCategory, setFeedbackCategory] = useState<InquiryCategory>('その他');
 
   // UI状態
   const [isLoading, setIsLoading] = useState<boolean>(false);
@@ -225,43 +219,6 @@ export default function Profile({ staff: initialStaff }: ProfileProps) {
     }
   };
 
-  // フィードバック送信ハンドラ
-  const handleFeedbackSubmit = async () => {
-    // バリデーション
-    if (!feedbackTitle.trim()) {
-      toast.error('件名を入力してください');
-      return;
-    }
-
-    if (!feedbackContent.trim()) {
-      toast.error('フィードバック内容を入力してください');
-      return;
-    }
-
-    setIsLoading(true);
-
-    try {
-      // 問い合わせAPIを使用して送信
-      const response = await inquiryApi.createInquiry({
-        title: feedbackTitle,
-        content: feedbackContent,
-        category: feedbackCategory,
-      });
-
-      toast.success(response.message || 'フィードバックを送信しました。ご協力ありがとうございます。');
-
-      // フォームをクリア
-      setFeedbackTitle('');
-      setFeedbackContent('');
-      setFeedbackCategory('その他');
-    } catch (error) {
-      const message = error instanceof Error ? error.message : String(error);
-      toast.error(message || 'フィードバックの送信に失敗しました。しばらく時間をおいてからお試しください。');
-    } finally {
-      setIsLoading(false);
-    }
-  };
-
   return (
     <div className="min-h-screen bg-slate-100 text-slate-900 dark:bg-gray-900 dark:text-gray-200">
       {/* タブバー */}
@@ -285,7 +242,7 @@ export default function Profile({ staff: initialStaff }: ProfileProps) {
                 : 'text-slate-600 hover:text-slate-950 dark:text-gray-400 dark:hover:text-white'
             }`}
           >
-            フィードバック
+            不具合・ご要望
           </button>
           <button
             onClick={() => setActiveTab('notifications')}
@@ -554,91 +511,7 @@ export default function Profile({ staff: initialStaff }: ProfileProps) {
 
         {/* フィードバックタブ */}
         {activeTab === 'feedback' && (
-          <div className="max-w-3xl mx-auto">
-            <h2 className="text-3xl font-bold mb-7">フィードバック</h2>
-
-            <div className="bg-white border border-slate-300 shadow-sm dark:bg-[#1a1a2e] dark:border-[#2a2a3e] rounded-xl p-6">
-              {/* 説明セクション */}
-              <div className="mb-7 bg-blue-50 border border-blue-200 dark:bg-blue-900/20 dark:border-blue-700/30 rounded-lg p-5">
-                <div className="flex items-start gap-3">
-                  <svg className="w-6 h-6 text-blue-400 mt-0.5 flex-shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
-                  </svg>
-                  <div>
-                    <h3 className="text-blue-800 dark:text-blue-300 font-semibold mb-2">アプリ運営者へのフィードバック</h3>
-                    <p className="text-blue-700 dark:text-blue-200 text-base leading-relaxed">
-                      このフォームは、アプリの運営者に直接フィードバックを送信するためのものです。<br />
-                      ご意見・ご要望・不具合報告など、お気軽にお送りください。
-                    </p>
-                  </div>
-                </div>
-              </div>
-
-              {/* フォーム */}
-              <div className="space-y-6">
-                {/* カテゴリ選択 */}
-                <div>
-                  <label className="text-slate-600 dark:text-gray-400 text-base block mb-2">カテゴリ</label>
-                  <select
-                    value={feedbackCategory}
-                    onChange={(e) => setFeedbackCategory(e.target.value as InquiryCategory)}
-                    className="w-full bg-white border border-slate-300 rounded-lg px-5 py-3 text-lg text-slate-900 dark:bg-[#0f1419] dark:border-[#2a2a3e] dark:text-white focus:outline-none focus:border-blue-500"
-                  >
-                    <option value="不具合">不具合報告</option>
-                    <option value="質問">質問</option>
-                    <option value="その他">その他（ご意見・ご要望）</option>
-                  </select>
-                </div>
-
-                {/* 件名入力 */}
-                <div>
-                  <label className="text-slate-600 dark:text-gray-400 text-base block mb-2">
-                    件名 <span className="text-red-400">*</span>
-                  </label>
-                  <input
-                    type="text"
-                    value={feedbackTitle}
-                    onChange={(e) => setFeedbackTitle(e.target.value)}
-                    placeholder="例: ログイン画面で不具合があります"
-                    maxLength={200}
-                    className="w-full bg-white border border-slate-300 rounded-lg px-5 py-3 text-lg text-slate-900 dark:bg-[#0f1419] dark:border-[#2a2a3e] dark:text-white placeholder-slate-500 dark:placeholder-[#666] focus:outline-none focus:border-blue-500"
-                  />
-                  <p className="text-slate-500 dark:text-gray-500 text-base mt-1">
-                    {feedbackTitle.length} / 200文字
-                  </p>
-                </div>
-
-                {/* 内容入力 */}
-                <div>
-                  <label className="text-slate-600 dark:text-gray-400 text-base block mb-2">
-                    内容 <span className="text-red-400">*</span>
-                  </label>
-                  <textarea
-                    rows={8}
-                    value={feedbackContent}
-                    onChange={(e) => setFeedbackContent(e.target.value)}
-                    placeholder="フィードバック内容を入力してください...&#10;&#10;【不具合報告の場合】&#10;・発生した状況&#10;・エラーメッセージ&#10;・再現手順&#10;などを記載いただけると助かります。"
-                    maxLength={20000}
-                    className="w-full bg-white border border-slate-300 rounded-lg px-5 py-4 text-lg text-slate-900 dark:bg-[#0f1419] dark:border-[#2a2a3e] dark:text-white placeholder-slate-500 dark:placeholder-[#666] focus:outline-none focus:border-blue-500 resize-none"
-                  />
-                  <p className="text-slate-500 dark:text-gray-500 text-base mt-1">
-                    {feedbackContent.length} / 20,000文字
-                  </p>
-                </div>
-
-                {/* 送信ボタン */}
-                <div className="flex gap-3">
-                  <button
-                    onClick={handleFeedbackSubmit}
-                    disabled={isLoading || !feedbackTitle.trim() || !feedbackContent.trim()}
-                    className="bg-blue-600 hover:bg-blue-700 text-white px-7 py-3 rounded-lg font-semibold disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
-                  >
-                    {isLoading ? '送信中...' : '運営者に送信'}
-                  </button>
-                </div>
-              </div>
-            </div>
-          </div>
+          <FeedbackForm />
         )}
 
         {/* 通知設定タブ */}

--- a/lib/http.ts
+++ b/lib/http.ts
@@ -17,6 +17,30 @@ export const setCsrfToken = (token: string) => {
  */
 export const getCsrfToken = () => csrfToken;
 
+const fetchCsrfToken = async (): Promise<string> => {
+  const response = await fetch(`${API_BASE_URL}/api/v1/csrf-token`, {
+    method: 'GET',
+    credentials: 'include',
+  });
+
+  if (!response.ok) {
+    throw new Error('CSRFトークンの取得に失敗しました');
+  }
+
+  const data = await response.json() as { csrf_token: string };
+  setCsrfToken(data.csrf_token);
+  return data.csrf_token;
+};
+
+const ensureCsrfToken = async (): Promise<string> => {
+  if (csrfToken) return csrfToken;
+  return fetchCsrfToken();
+};
+
+const isCsrfFailure = (response: Response, errorData: FastAPIErrorResponse): boolean => {
+  return response.status === 403 && errorData.detail === 'CSRF token validation failed';
+};
+
 // FastAPIのバリデーションエラーの型定義
 interface ValidationError {
   loc: (string | number)[];
@@ -147,8 +171,8 @@ async function request<T>(endpoint: string, options: RequestInit = {}): Promise<
   const method = options.method?.toUpperCase();
   const isStateMutatingMethod = ['POST', 'PUT', 'PATCH', 'DELETE'].includes(method || '');
 
-  if (isStateMutatingMethod && csrfToken) {
-    defaultHeaders['X-CSRF-Token'] = csrfToken;
+  if (isStateMutatingMethod) {
+    defaultHeaders['X-CSRF-Token'] = await ensureCsrfToken();
   }
 
   const config: RequestInit = {
@@ -170,6 +194,24 @@ async function request<T>(endpoint: string, options: RequestInit = {}): Promise<
       throw new Error('認証されていません');
     }
     const errorData = await response.json().catch(() => ({ detail: `リクエストが失敗しました (ステータス: ${response.status})` }));
+    if (isStateMutatingMethod && isCsrfFailure(response, errorData)) {
+      const refreshedToken = await fetchCsrfToken();
+      const retryResponse = await fetch(url, {
+        ...config,
+        headers: {
+          ...defaultHeaders,
+          ...options.headers,
+          'X-CSRF-Token': refreshedToken,
+        },
+      });
+
+      if (retryResponse.ok) {
+        if (retryResponse.status === 204) {
+          return Promise.resolve(null as T);
+        }
+        return retryResponse.json();
+      }
+    }
     const errorMessage = formatErrorMessage(errorData);
     throw new Error(errorMessage);
   }
@@ -181,18 +223,21 @@ async function request<T>(endpoint: string, options: RequestInit = {}): Promise<
   return response.json();
 }
 
-async function requestWithFormData<T>(endpoint: string, formData: FormData): Promise<T> {
+async function requestWithFormData<T>(
+  endpoint: string,
+  formData: FormData,
+  method: 'POST' | 'PUT' = 'POST'
+): Promise<T> {
   const url = `${API_BASE_URL}${endpoint}`;
 
-  // POSTリクエストなので、CSRFトークンをヘッダーに追加
-  const headers: HeadersInit = {};
-  if (csrfToken) {
-    headers['X-CSRF-Token'] = csrfToken;
-  }
+  // 状態変更リクエストなので、CSRFトークンをヘッダーに追加
+  const headers: HeadersInit = {
+    'X-CSRF-Token': await ensureCsrfToken(),
+  };
 
   // Cookie認証: credentials: 'include' により自動的にCookieが送信される
   const config: RequestInit = {
-    method: 'POST',
+    method,
     credentials: 'include', // Cookie送信のため必須
     headers,
     body: formData,
@@ -207,6 +252,22 @@ async function requestWithFormData<T>(endpoint: string, formData: FormData): Pro
       throw new Error('認証されていません');
     }
     const errorData = await response.json().catch(() => ({ detail: `リクエストが失敗しました (ステータス: ${response.status})` }));
+    if (isCsrfFailure(response, errorData)) {
+      const refreshedToken = await fetchCsrfToken();
+      const retryResponse = await fetch(url, {
+        ...config,
+        headers: {
+          'X-CSRF-Token': refreshedToken,
+        },
+      });
+
+      if (retryResponse.ok) {
+        if (retryResponse.status === 204) {
+          return Promise.resolve(null as T);
+        }
+        return retryResponse.json();
+      }
+    }
     const errorMessage = formatErrorMessage(errorData);
     throw new Error(errorMessage);
   }
@@ -225,4 +286,5 @@ export const http = {
   patch: <T>(endpoint: string, body: unknown, options?: RequestInit) => request<T>(endpoint, { ...options, method: 'PATCH', body: JSON.stringify(body) }),
   delete: <T>(endpoint: string, options?: RequestInit) => request<T>(endpoint, { ...options, method: 'DELETE' }),
   postFormData: <T>(endpoint: string, formData: FormData) => requestWithFormData<T>(endpoint, formData),
+  putFormData: <T>(endpoint: string, formData: FormData) => requestWithFormData<T>(endpoint, formData, 'PUT'),
 };

--- a/lib/support-plan.ts
+++ b/lib/support-plan.ts
@@ -55,20 +55,10 @@ export const supportPlanApi = {
     formData.append('plan_cycle_id', cycleId);
     formData.append('deliverable_type', deliverableType);
 
-    const API_BASE_URL = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:8000';
-
-    // Cookieで認証されるため、credentials: 'include'を追加
-    return fetch(`${API_BASE_URL}/api/v1/support-plans/plan-deliverables`, {
-      method: 'POST',
-      credentials: 'include', // Cookie自動送信
-      body: formData,
-    }).then(async (res) => {
-      if (!res.ok) {
-        throw new Error(`アップロードに失敗しました: ${res.status} ${res.statusText}`);
-      }
-
-      return res.json();
-    });
+    return http.postFormData<{ success: boolean; message: string }>(
+      '/api/v1/support-plans/plan-deliverables',
+      formData
+    );
   },
 
   /**
@@ -78,17 +68,10 @@ export const supportPlanApi = {
     const formData = new FormData();
     formData.append('file', file);
 
-    const API_BASE_URL = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:8000';
-
-    // Cookieで認証されるため、credentials: 'include'を追加
-    return fetch(`${API_BASE_URL}/api/v1/support-plans/deliverables/${deliverableId}`, {
-      method: 'PUT',
-      credentials: 'include', // Cookie自動送信
-      body: formData,
-    }).then((res) => {
-      if (!res.ok) throw new Error('再アップロードに失敗しました');
-      return res.json();
-    });
+    return http.putFormData<{ success: boolean; message: string }>(
+      `/api/v1/support-plans/deliverables/${deliverableId}`,
+      formData
+    );
   },
 
   /**


### PR DESCRIPTION
## Summary
- fetch and retry CSRF tokens automatically for JSON and FormData state-changing requests
- reuse the feedback form across profile and notice surfaces
- polish protected/app-admin UI states and fix inquiry reply data wiring

## Validation
- npx tsc --noEmit
- npm run lint (passes with existing unused-variable warnings)