### PR TITLE
fix: decouple auth flow from CSRF prefetch

### DIFF
--- a/lib/auth.ts
+++ b/lib/auth.ts
@@ -1,15 +1,21 @@
 import { http } from './http';
 import { tokenUtils } from './token';
 import { initializeCsrfToken } from './csrf';
+import { createAuthFlowClient } from './authFlow';
 
 const API_BASE_URL = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:8000';
 const API_V1_PREFIX = '/api/v1';
-import { LoginData, AuthResponse } from '@/types/auth';
 import { AdminCreateData, StaffCreateData, StaffResponse } from '@/types/staff';
 import { OfficeCreateData, OfficeResponse } from '@/types/office';
 
 // Re-export tokenUtils for convenience
 export { tokenUtils };
+
+const authFlowClient = createAuthFlowClient({
+  apiBaseUrl: API_BASE_URL,
+  apiV1Prefix: API_V1_PREFIX,
+  initializeCsrfToken,
+});
 
 // Authentication API calls
 export const authApi = {
@@ -21,40 +27,7 @@ export const authApi = {
     return http.post<StaffResponse>(`${API_V1_PREFIX}/auth/register`, data);
   },
 
-  login: async (data: LoginData): Promise<AuthResponse> => {
-    const params = new URLSearchParams({
-      username: data.username,
-      password: data.password,
-    });
-    // app_admin用合言葉がある場合は追加
-    if (data.passphrase) {
-      params.append('passphrase', data.passphrase);
-    }
-    const response = await fetch(`${API_BASE_URL}${API_V1_PREFIX}/auth/token`, {
-      method: 'POST',
-      credentials: 'include', // Cookie送信のため追加
-      headers: {
-        'Content-Type': 'application/x-www-form-urlencoded',
-      },
-      body: params,
-    });
-
-    if (!response.ok) {
-      const error = await response.json();
-      throw new Error(error.detail || 'ログインに失敗しました');
-    }
-
-    const authResponse = await response.json();
-
-    // access_tokenはCookieで管理されるため、localStorageへの保存は不要
-    // Cookieはサーバー側で自動的に設定される
-
-    // ログイン成功後、CSRFトークンを初期化
-    // Cookie認証を使用するため、状態変更リクエストにはCSRFトークンが必要
-    await initializeCsrfToken();
-
-    return authResponse;
-  },
+  login: authFlowClient.login,
 
   getCurrentUser: (): Promise<StaffResponse> => {
     return http.get<StaffResponse>(`${API_V1_PREFIX}/staffs/me`);
@@ -64,18 +37,9 @@ export const authApi = {
     return http.get<{ message: string; role: string }>(`${API_V1_PREFIX}/auth/verify-email?token=${token}`);
   },
 
-  logout: (): Promise<{ message: string }> => {
-    return http.post<{ message: string }>(`${API_V1_PREFIX}/auth/logout`, {});
-  },
+  logout: authFlowClient.logout,
 
-  verifyMfa: async (data: { temporary_token: string; totp_code: string }): Promise<AuthResponse> => {
-    const response = await http.post<AuthResponse>(`${API_V1_PREFIX}/auth/token/verify-mfa`, data);
-
-    // MFA検証成功後もCSRFトークンを初期化
-    await initializeCsrfToken();
-
-    return response;
-  },
+  verifyMfa: authFlowClient.verifyMfa,
 
   // Admin MFA management
   enableStaffMfa: (staffId: string): Promise<{

--- a/lib/authFlow.test.mjs
+++ b/lib/authFlow.test.mjs
@@ -1,0 +1,77 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import { createAuthFlowClient } from './authFlow.ts';
+
+const okJsonResponse = (body) =>
+  new Response(JSON.stringify(body), {
+    status: 200,
+    headers: { 'Content-Type': 'application/json' },
+  });
+
+test('login returns auth response even when csrf initialization fails after success', async () => {
+  const calls = [];
+  const client = createAuthFlowClient({
+    apiBaseUrl: 'http://backend.test',
+    apiV1Prefix: '/api/v1',
+    fetchImpl: async (url, init) => {
+      calls.push({ url: String(url), init });
+      return okJsonResponse({ role: 'owner', requires_mfa_verification: false });
+    },
+    initializeCsrfToken: async () => false,
+  });
+
+  const result = await client.login({
+    username: 'owner@example.com',
+    password: 'password',
+  });
+
+  assert.equal(result.role, 'owner');
+  assert.equal(calls.length, 1);
+  assert.equal(calls[0].url, 'http://backend.test/api/v1/auth/token');
+});
+
+test('verifyMfa posts to exempt endpoint without csrf prefetch and tolerates csrf init failure', async () => {
+  const calls = [];
+  const client = createAuthFlowClient({
+    apiBaseUrl: 'http://backend.test',
+    apiV1Prefix: '/api/v1',
+    fetchImpl: async (url, init) => {
+      calls.push({ url: String(url), init });
+      return okJsonResponse({ role: 'manager', requires_mfa_verification: false });
+    },
+    initializeCsrfToken: async () => false,
+  });
+
+  const result = await client.verifyMfa({
+    temporary_token: 'temporary-token',
+    totp_code: '123456',
+  });
+
+  assert.equal(result.role, 'manager');
+  assert.equal(calls.length, 1);
+  assert.equal(calls[0].url, 'http://backend.test/api/v1/auth/token/verify-mfa');
+  assert.equal(calls[0].init?.headers?.['X-CSRF-Token'], undefined);
+});
+
+test('logout posts to exempt endpoint without csrf prefetch', async () => {
+  const calls = [];
+  const client = createAuthFlowClient({
+    apiBaseUrl: 'http://backend.test',
+    apiV1Prefix: '/api/v1',
+    fetchImpl: async (url, init) => {
+      calls.push({ url: String(url), init });
+      return okJsonResponse({ message: 'ログアウトしました' });
+    },
+    initializeCsrfToken: async () => {
+      throw new Error('csrf should not be initialized for logout');
+    },
+  });
+
+  const result = await client.logout();
+
+  assert.equal(result.message, 'ログアウトしました');
+  assert.equal(calls.length, 1);
+  assert.equal(calls[0].url, 'http://backend.test/api/v1/auth/logout');
+  assert.equal(calls[0].init?.method, 'POST');
+});

--- a/lib/authFlow.ts
+++ b/lib/authFlow.ts
@@ -1,0 +1,102 @@
+import type { LoginData, AuthResponse } from '@/types/auth';
+
+type FetchLike = (input: string, init?: RequestInit) => Promise<Response>;
+type InitializeCsrfToken = () => Promise<boolean>;
+
+interface AuthFlowClientOptions {
+  apiBaseUrl: string;
+  apiV1Prefix: string;
+  fetchImpl?: FetchLike;
+  initializeCsrfToken: InitializeCsrfToken;
+}
+
+interface MfaVerifyData {
+  temporary_token: string;
+  totp_code: string;
+}
+
+async function parseErrorMessage(response: Response, fallback: string): Promise<string> {
+  const error = await response.json().catch(() => null) as { detail?: string } | null;
+  return error?.detail || fallback;
+}
+
+async function initializeCsrfTokenBestEffort(
+  initializeCsrfToken: InitializeCsrfToken
+): Promise<void> {
+  try {
+    await initializeCsrfToken();
+  } catch {
+    // 認証成功後のCSRF初期化はbest-effort。
+    // 次回の状態変更APIでhttp wrapperが遅延取得する。
+  }
+}
+
+export function createAuthFlowClient({
+  apiBaseUrl,
+  apiV1Prefix,
+  fetchImpl = fetch,
+  initializeCsrfToken,
+}: AuthFlowClientOptions) {
+  const authUrl = (path: string) => `${apiBaseUrl}${apiV1Prefix}${path}`;
+
+  return {
+    async login(data: LoginData): Promise<AuthResponse> {
+      const params = new URLSearchParams({
+        username: data.username,
+        password: data.password,
+      });
+      if (data.passphrase) {
+        params.append('passphrase', data.passphrase);
+      }
+
+      const response = await fetchImpl(authUrl('/auth/token'), {
+        method: 'POST',
+        credentials: 'include',
+        headers: {
+          'Content-Type': 'application/x-www-form-urlencoded',
+        },
+        body: params,
+      });
+
+      if (!response.ok) {
+        throw new Error(await parseErrorMessage(response, 'ログインに失敗しました'));
+      }
+
+      const authResponse = await response.json() as AuthResponse;
+      await initializeCsrfTokenBestEffort(initializeCsrfToken);
+      return authResponse;
+    },
+
+    async verifyMfa(data: MfaVerifyData): Promise<AuthResponse> {
+      const response = await fetchImpl(authUrl('/auth/token/verify-mfa'), {
+        method: 'POST',
+        credentials: 'include',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify(data),
+      });
+
+      if (!response.ok) {
+        throw new Error(await parseErrorMessage(response, 'MFA認証に失敗しました'));
+      }
+
+      const authResponse = await response.json() as AuthResponse;
+      await initializeCsrfTokenBestEffort(initializeCsrfToken);
+      return authResponse;
+    },
+
+    async logout(): Promise<{ message: string }> {
+      const response = await fetchImpl(authUrl('/auth/logout'), {
+        method: 'POST',
+        credentials: 'include',
+      });
+
+      if (!response.ok) {
+        throw new Error(await parseErrorMessage(response, 'ログアウトに失敗しました'));
+      }
+
+      return await response.json() as { message: string };
+    },
+  };
+}


### PR DESCRIPTION
## Summary
- Add `authFlow` client for CSRF-exempt auth endpoints.
- Make login/MFA CSRF initialization best-effort after successful auth.
- Make MFA verify and logout call exempt endpoints without requiring CSRF prefetch.

## Tests
- `node --experimental-strip-types --test lib/authFlow.test.mjs`
  - 3 passed
- `npm run lint`
  - 0 errors, 16 existing warnings
- `npx tsc --noEmit --pretty false`
  - passed

## Related
- Backend PR: https://github.com/nto300002/keikakun_back/pull/86
- App issue: https://github.com/nto300002/keikakun_app/issues/166