### PR TITLE
[codex] Fix notice message display labels

### DIFF
--- a/app/(protected)/notice/page.tsx
+++ b/app/(protected)/notice/page.tsx
@@ -6,6 +6,7 @@ import DeadlineAlertsTab from '@/components/notice/DeadlineAlertsTab';
 import MessagesTab from '@/components/notice/MessagesTab';
 import MessageSendForm from '@/components/messages/MessageSendForm';
 import FeedbackForm from '@/components/protected/profile/FeedbackForm';
+import { getNoticeTabLabel } from '@/components/notice/messageDisplay';
 
 type TabType = 'messages' | 'approvals' | 'deadlines' | 'send' | 'feedback';
 type CategoryType = 'recipients' | 'messages' | 'feedback';
@@ -67,7 +68,7 @@ export default function NoticePage() {
               : 'text-slate-600 hover:text-slate-950 hover:bg-slate-100 dark:text-gray-400 dark:hover:text-gray-200 dark:hover:bg-gray-800/30'
           }`}
         >
-          不具合/ご要望
+          {getNoticeTabLabel('feedback')}
         </button>
       </div>
 

--- a/components/messages/MessageSendForm.tsx
+++ b/components/messages/MessageSendForm.tsx
@@ -87,7 +87,7 @@ export default function MessageSendForm() {
       return;
     }
     if (messageType === 'announcement' && currentUserRole !== 'owner' && currentUserRole !== 'manager') {
-      toast.error('一斉通知を送信する権限がありません');
+      toast.error('お知らせを送信する権限がありません');
       return;
     }
 
@@ -107,7 +107,7 @@ export default function MessageSendForm() {
           content,
           priority,
         });
-        toast.success('一斉通知を送信しました');
+        toast.success('お知らせを送信しました');
       }
 
       // 送信成功後、通知ページにリダイレクト
@@ -152,7 +152,7 @@ export default function MessageSendForm() {
                   : 'bg-slate-200 text-slate-900 hover:bg-slate-300 dark:bg-gray-700/50 dark:text-gray-300 dark:hover:bg-gray-600/70 border-2 border-slate-300 dark:border-gray-600'
               } disabled:opacity-50 disabled:cursor-not-allowed`}
             >
-              📢 一斉通知
+              📢 お知らせ
               {(currentUserRole !== 'owner' && currentUserRole !== 'manager') && (
                 <span className="block text-sm mt-1">(オーナー/管理者のみ)</span>
               )}

--- a/components/notice/MessageCard.tsx
+++ b/components/notice/MessageCard.tsx
@@ -1,6 +1,7 @@
 'use client';
 
-import { MessageInboxItem, MessageType, MessagePriority } from '@/types/message';
+import { MessageInboxItem, MessagePriority } from '@/types/message';
+import { getMessageDisplayMeta, getMessageSenderLabel } from './messageDisplay';
 
 interface MessageCardProps {
   message: MessageInboxItem;
@@ -13,88 +14,6 @@ export default function MessageCard({
   onMarkAsRead,
   onArchive,
 }: MessageCardProps) {
-  // メッセージタイプに応じたスタイルとアイコン
-  const getMessageStyle = (type: MessageType, priority: MessagePriority) => {
-    // 優先度による色の決定
-    if (priority === MessagePriority.URGENT) {
-      return {
-        icon: '🚨',
-        color: 'red',
-        bgColor: 'bg-red-50 dark:bg-red-900/30',
-        borderColor: 'border-red-200 dark:border-red-700/50',
-        textColor: 'text-red-700 dark:text-red-400',
-      };
-    } else if (priority === MessagePriority.HIGH) {
-      return {
-        icon: '⚠️',
-        color: 'orange',
-        bgColor: 'bg-orange-50 dark:bg-orange-900/30',
-        borderColor: 'border-orange-200 dark:border-orange-700/50',
-        textColor: 'text-orange-700 dark:text-orange-400',
-      };
-    }
-
-    // メッセージタイプによる色の決定（通常・低優先度）
-    switch (type) {
-      case MessageType.PERSONAL:
-        return {
-          icon: '💬',
-          color: 'blue',
-          bgColor: 'bg-blue-50 dark:bg-blue-900/30',
-          borderColor: 'border-blue-200 dark:border-blue-700/50',
-          textColor: 'text-blue-700 dark:text-blue-400',
-        };
-      case MessageType.ANNOUNCEMENT:
-        return {
-          icon: '📢',
-          color: 'purple',
-          bgColor: 'bg-purple-50 dark:bg-purple-900/30',
-          borderColor: 'border-purple-200 dark:border-purple-700/50',
-          textColor: 'text-purple-700 dark:text-purple-400',
-        };
-      case MessageType.SYSTEM:
-        return {
-          icon: '⚙️',
-          color: 'gray',
-          bgColor: 'bg-slate-50 dark:bg-gray-900/30',
-          borderColor: 'border-slate-200 dark:border-gray-700/50',
-          textColor: 'text-slate-600 dark:text-gray-400',
-        };
-      case MessageType.INQUIRY:
-        return {
-          icon: '❓',
-          color: 'teal',
-          bgColor: 'bg-teal-50 dark:bg-teal-900/30',
-          borderColor: 'border-teal-200 dark:border-teal-700/50',
-          textColor: 'text-teal-700 dark:text-teal-400',
-        };
-      default:
-        return {
-          icon: 'ℹ️',
-          color: 'blue',
-          bgColor: 'bg-blue-50 dark:bg-blue-900/30',
-          borderColor: 'border-blue-200 dark:border-blue-700/50',
-          textColor: 'text-blue-700 dark:text-blue-400',
-        };
-    }
-  };
-
-  // メッセージタイプのラベル
-  const getMessageTypeLabel = (type: MessageType) => {
-    switch (type) {
-      case MessageType.PERSONAL:
-        return '個別メッセージ';
-      case MessageType.ANNOUNCEMENT:
-        return 'お知らせ';
-      case MessageType.SYSTEM:
-        return 'システム通知';
-      case MessageType.INQUIRY:
-        return 'お問い合わせ';
-      default:
-        return 'メッセージ';
-    }
-  };
-
   // 優先度のラベル
   const getPriorityLabel = (priority: MessagePriority) => {
     switch (priority) {
@@ -111,18 +30,19 @@ export default function MessageCard({
     }
   };
 
-  const style = getMessageStyle(message.message_type, message.priority);
+  const style = getMessageDisplayMeta(message.message_type, message.priority);
+  const senderLabel = getMessageSenderLabel(message);
 
   return (
     <div
-      className={`${style.bgColor} border ${style.borderColor} rounded-lg p-5 mb-4 ${
+      className={`${style.cardClassName} border ${style.borderClassName} rounded-lg p-5 mb-4 ${
         message.is_read ? 'opacity-60' : ''
       }`}
     >
       {/* ヘッダー部分 */}
       <div className="flex items-start justify-between mb-4">
         <div className="flex items-start gap-3 flex-1">
-          <span className={`text-3xl ${style.textColor}`}>{style.icon}</span>
+          <span className={`text-3xl ${style.textClassName}`}>{style.icon}</span>
           <div className="flex-1">
             <div className="flex items-center gap-2 mb-2">
                 <span className="text-slate-900 font-bold text-xl dark:text-white">{message.title}</span>
@@ -147,13 +67,13 @@ export default function MessageCard({
             {/* メッセージタイプラベルと送信者情報 */}
             <div className="flex items-center gap-2 mb-2">
               <span
-                  className={`inline-block px-3 py-1 rounded text-sm font-bold ${style.textColor} bg-white/70 dark:bg-gray-800/50`}
+                  className={`inline-block px-3 py-1 rounded text-sm font-bold ${style.badgeClassName}`}
               >
-                {getMessageTypeLabel(message.message_type)}
+                {style.label}
               </span>
-              {message.sender && (
+              {senderLabel && (
                 <span className="text-slate-600 text-base font-semibold dark:text-gray-400">
-                  送信者: {message.sender.last_name} {message.sender.first_name}
+                  {senderLabel}
                 </span>
               )}
             </div>

--- a/components/notice/messageDisplay.test.mjs
+++ b/components/notice/messageDisplay.test.mjs
@@ -1,0 +1,78 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import {
+  getMessageDisplayMeta,
+  getMessageSenderLabel,
+  getNoticeTabLabel,
+  getProfileFeedbackLabel,
+} from './messageDisplay.ts';
+
+function buildMessage(overrides = {}) {
+  return {
+    message_id: 'message-1',
+    message_type: 'personal',
+    priority: 'normal',
+    title: '件名',
+    content: '本文',
+    sender_staff_id: 'staff-1',
+    sender: {
+      id: 'staff-1',
+      username: 'sender',
+      email: 'sender@example.com',
+      first_name: '太郎',
+      last_name: '送信',
+    },
+    is_read: false,
+    read_at: null,
+    is_archived: false,
+    created_at: '2026-07-07T00:00:00Z',
+    updated_at: '2026-07-07T00:00:00Z',
+    ...overrides,
+  };
+}
+
+test('announcement messages are displayed as notices, not other messages', () => {
+  const meta = getMessageDisplayMeta('announcement', 'normal');
+
+  assert.equal(meta.label, 'お知らせ');
+  assert.equal(meta.tone, 'notice');
+  assert.match(meta.badgeClassName, /purple|emerald|green/);
+});
+
+test('personal and fallback message styles are visually distinct', () => {
+  const personal = getMessageDisplayMeta('personal', 'normal');
+  const fallback = getMessageDisplayMeta('unknown', 'normal');
+
+  assert.equal(personal.label, '個別');
+  assert.equal(fallback.label, 'その他');
+  assert.notEqual(personal.tone, fallback.tone);
+  assert.notEqual(personal.badgeClassName, fallback.badgeClassName);
+});
+
+test('app admin announcements hide the sender identity', () => {
+  const message = buildMessage({
+    message_type: 'announcement',
+    sender_staff_id: null,
+    sender: {
+      id: 'app-admin',
+      username: 'app_admin',
+      email: 'admin@example.com',
+      first_name: '管理',
+      last_name: '運営',
+    },
+  });
+
+  assert.equal(getMessageSenderLabel(message), '送信者: 運営');
+});
+
+test('office personal messages keep the sender name', () => {
+  const message = buildMessage();
+
+  assert.equal(getMessageSenderLabel(message), '送信者: 送信 太郎');
+});
+
+test('feedback wording is unified as inquiries', () => {
+  assert.equal(getNoticeTabLabel('feedback'), 'お問い合わせ');
+  assert.equal(getProfileFeedbackLabel(), 'お問い合わせ');
+});

--- a/components/notice/messageDisplay.ts
+++ b/components/notice/messageDisplay.ts
@@ -1,0 +1,124 @@
+import type { MessageInboxItem, MessagePriority, MessageType } from '../../types/message';
+
+export type MessageDisplayTone = 'personal' | 'notice' | 'system' | 'inquiry' | 'other' | 'urgent' | 'high';
+
+export interface MessageDisplayMeta {
+  icon: string;
+  label: string;
+  tone: MessageDisplayTone;
+  cardClassName: string;
+  borderClassName: string;
+  textClassName: string;
+  badgeClassName: string;
+}
+
+const urgentMeta: MessageDisplayMeta = {
+  icon: '🚨',
+  label: '緊急',
+  tone: 'urgent',
+  cardClassName: 'bg-red-50 dark:bg-red-900/30',
+  borderClassName: 'border-red-200 dark:border-red-700/50',
+  textClassName: 'text-red-700 dark:text-red-400',
+  badgeClassName: 'bg-red-100 text-red-800 dark:bg-red-900/50 dark:text-red-200',
+};
+
+const highMeta: MessageDisplayMeta = {
+  icon: '⚠️',
+  label: '高優先',
+  tone: 'high',
+  cardClassName: 'bg-orange-50 dark:bg-orange-900/30',
+  borderClassName: 'border-orange-200 dark:border-orange-700/50',
+  textClassName: 'text-orange-700 dark:text-orange-400',
+  badgeClassName: 'bg-orange-100 text-orange-800 dark:bg-orange-900/50 dark:text-orange-200',
+};
+
+const metaByType: Record<string, MessageDisplayMeta> = {
+  personal: {
+    icon: '💬',
+    label: '個別',
+    tone: 'personal',
+    cardClassName: 'bg-blue-50 dark:bg-blue-900/30',
+    borderClassName: 'border-blue-200 dark:border-blue-700/50',
+    textClassName: 'text-blue-700 dark:text-blue-400',
+    badgeClassName: 'bg-blue-100 text-blue-800 dark:bg-blue-900/50 dark:text-blue-200',
+  },
+  announcement: {
+    icon: '📢',
+    label: 'お知らせ',
+    tone: 'notice',
+    cardClassName: 'bg-purple-50 dark:bg-purple-900/30',
+    borderClassName: 'border-purple-200 dark:border-purple-700/50',
+    textClassName: 'text-purple-700 dark:text-purple-400',
+    badgeClassName: 'bg-purple-100 text-purple-800 dark:bg-purple-900/50 dark:text-purple-200',
+  },
+  system: {
+    icon: '⚙️',
+    label: 'システム',
+    tone: 'system',
+    cardClassName: 'bg-slate-50 dark:bg-gray-900/30',
+    borderClassName: 'border-slate-200 dark:border-gray-700/50',
+    textClassName: 'text-slate-600 dark:text-gray-400',
+    badgeClassName: 'bg-slate-200 text-slate-800 dark:bg-gray-800 dark:text-gray-200',
+  },
+  inquiry: {
+    icon: '❓',
+    label: 'お問い合わせ',
+    tone: 'inquiry',
+    cardClassName: 'bg-teal-50 dark:bg-teal-900/30',
+    borderClassName: 'border-teal-200 dark:border-teal-700/50',
+    textClassName: 'text-teal-700 dark:text-teal-400',
+    badgeClassName: 'bg-teal-100 text-teal-800 dark:bg-teal-900/50 dark:text-teal-200',
+  },
+};
+
+const fallbackMeta: MessageDisplayMeta = {
+  icon: 'ℹ️',
+  label: 'その他',
+  tone: 'other',
+  cardClassName: 'bg-slate-50 dark:bg-gray-900/30',
+  borderClassName: 'border-slate-200 dark:border-gray-700/50',
+  textClassName: 'text-slate-600 dark:text-gray-400',
+  badgeClassName: 'bg-slate-200 text-slate-800 dark:bg-gray-800 dark:text-gray-200',
+};
+
+export function getMessageDisplayMeta(type: MessageType | string, priority: MessagePriority | string): MessageDisplayMeta {
+  if (priority === 'urgent') return urgentMeta;
+  if (priority === 'high') return highMeta;
+
+  return metaByType[type] ?? fallbackMeta;
+}
+
+export function getMessageTypeLabel(type: MessageType | string): string {
+  return metaByType[type]?.label ?? fallbackMeta.label;
+}
+
+export function isAppAdminAnnouncement(message: MessageInboxItem): boolean {
+  if (message.message_type !== 'announcement') return false;
+  if (message.sender_staff_id === null) return true;
+
+  const sender = message.sender;
+  if (!sender) return false;
+
+  return sender.role === 'app_admin' || sender.username === 'app_admin';
+}
+
+export function getMessageSenderLabel(message: MessageInboxItem): string | null {
+  if (isAppAdminAnnouncement(message)) {
+    return '送信者: 運営';
+  }
+
+  if (!message.sender) return null;
+
+  const name = [message.sender.last_name, message.sender.first_name].filter(Boolean).join(' ').trim();
+  if (name) return `送信者: ${name}`;
+
+  return '送信者: スタッフ';
+}
+
+export function getNoticeTabLabel(tab: 'feedback' | string): string {
+  return tab === 'feedback' ? 'お問い合わせ' : tab;
+}
+
+export function getProfileFeedbackLabel(): string {
+  return 'お問い合わせ';
+}

--- a/components/protected/profile/FeedbackForm.tsx
+++ b/components/protected/profile/FeedbackForm.tsx
@@ -4,6 +4,7 @@ import { useState } from 'react';
 import { toast } from '@/lib/toast-debug';
 import { inquiryApi } from '@/lib/api/inquiry';
 import type { InquiryCategory } from '@/types/inquiry';
+import { getProfileFeedbackLabel } from '@/components/notice/messageDisplay';
 
 export default function FeedbackForm() {
   const [feedbackContent, setFeedbackContent] = useState('');
@@ -45,7 +46,7 @@ export default function FeedbackForm() {
 
   return (
     <div className="max-w-3xl mx-auto">
-      <h2 className="text-3xl font-bold mb-7">不具合・ご要望</h2>
+      <h2 className="text-3xl font-bold mb-7">{getProfileFeedbackLabel()}</h2>
 
       <div className="bg-white border border-slate-300 shadow-sm dark:bg-[#1a1a2e] dark:border-[#2a2a3e] rounded-xl p-6">
         <div className="mb-7 bg-blue-50 border border-blue-200 dark:bg-blue-900/20 dark:border-blue-700/30 rounded-lg p-5">

--- a/components/protected/profile/Profile.tsx
+++ b/components/protected/profile/Profile.tsx
@@ -242,7 +242,7 @@ export default function Profile({ staff: initialStaff }: ProfileProps) {
                 : 'text-slate-600 hover:text-slate-950 dark:text-gray-400 dark:hover:text-white'
             }`}
           >
-            不具合・ご要望
+            お問い合わせ
           </button>
           <button
             onClick={() => setActiveTab('notifications')}

--- a/types/message.ts
+++ b/types/message.ts
@@ -20,6 +20,7 @@ export interface MessageSenderInfo {
   id: string;
   username: string;
   email: string;
+  role?: string;
   // バックエンドのレスポンスで first_name / last_name が含まれるため追加
   first_name?: string;
   last_name?: string;


### PR DESCRIPTION
## Summary
- お知らせメッセージを、他のラベルや「メッセージ」ラベルにフォールバックすることなく、「お知らせ」として表示する
- app_admin からの通知送信者情報を、固定の「運営」という送信者ラベルで隠す
- メッセージタイプのバッジトーンを「個別」「お知らせ」「システム」「その他」に分割し、テキストラベルは維持する
- 表示されている「不具合・ご要望」「不具合」「ご要望」のエントリーポイントを「お問い合わせ」に名称変更する

## TDD
Red:
- added messageDisplay helper tests for announcement classification, fallback styling, app_admin sender hiding, normal sender display, and inquiry wording

Green:
- introduced shared message display metadata and connected MessageCard / notice tab / profile feedback labels

## Validation
- node --experimental-strip-types --test components/notice/messageDisplay.test.mjs
- npx eslint components/notice/messageDisplay.ts components/notice/messageDisplay.test.mjs components/notice/MessageCard.tsx app/'(protected)'/notice/page.tsx components/protected/profile/Profile.tsx components/protected/profile/FeedbackForm.tsx types/message.ts
- npx tsc --noEmit --pretty false
- npm run lint (passes with existing unrelated warnings)

Closes nto300002/keikakun_app#170