### PR TITLE
Fix app-admin inquiry and notification UI

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -25,6 +25,21 @@ body {
   font-family: Arial, Helvetica, sans-serif;
 }
 
+@keyframes notice-popover-stretch {
+  0% {
+    opacity: 0;
+    transform: scaleY(0.86) translateY(-6px);
+  }
+  70% {
+    opacity: 1;
+    transform: scaleY(1.03) translateY(0);
+  }
+  100% {
+    opacity: 1;
+    transform: scaleY(1) translateY(0);
+  }
+}
+
 @layer utilities {
   .hidden-scrollbar {
     -ms-overflow-style: none;    /* IE, Edge 対応 */

--- a/components/admin/inquiry/InquiryList.tsx
+++ b/components/admin/inquiry/InquiryList.tsx
@@ -68,7 +68,7 @@ export default function InquiryList({ onSelectInquiry }: InquiryListProps) {
       new: { bg: 'bg-red-500/20', text: 'text-red-400', label: '新規' },
       open: { bg: 'bg-yellow-500/20', text: 'text-yellow-400', label: '確認済み' },
       in_progress: { bg: 'bg-blue-500/20', text: 'text-blue-400', label: '対応中' },
-      answered: { bg: 'bg-green-500/20', text: 'text-green-400', label: '回答済み' },
+      answered: { bg: 'bg-green-100 dark:bg-green-500/20', text: 'text-green-700 dark:text-green-400', label: '回答済み' },
       closed: { bg: 'bg-gray-500/20', text: 'text-slate-600 dark:text-gray-400', label: 'クローズ' },
       spam: { bg: 'bg-purple-500/20', text: 'text-purple-400', label: 'スパム' },
     };

--- a/components/notice/messageDisplay.test.mjs
+++ b/components/notice/messageDisplay.test.mjs
@@ -40,6 +40,14 @@ test('announcement messages are displayed as notices, not other messages', () =>
   assert.match(meta.badgeClassName, /purple|emerald|green/);
 });
 
+test('inquiry replies are displayed as inquiry notices', () => {
+  const meta = getMessageDisplayMeta('inquiry_reply', 'normal');
+
+  assert.equal(meta.label, 'お問い合わせ返信');
+  assert.equal(meta.tone, 'inquiry');
+  assert.notEqual(meta.label, 'その他');
+});
+
 test('personal and fallback message styles are visually distinct', () => {
   const personal = getMessageDisplayMeta('personal', 'normal');
   const fallback = getMessageDisplayMeta('unknown', 'normal');

--- a/components/notice/messageDisplay.ts
+++ b/components/notice/messageDisplay.ts
@@ -69,6 +69,15 @@ const metaByType: Record<string, MessageDisplayMeta> = {
     textClassName: 'text-teal-700 dark:text-teal-400',
     badgeClassName: 'bg-teal-100 text-teal-800 dark:bg-teal-900/50 dark:text-teal-200',
   },
+  inquiry_reply: {
+    icon: '↩',
+    label: 'お問い合わせ返信',
+    tone: 'inquiry',
+    cardClassName: 'bg-teal-50 dark:bg-teal-900/30',
+    borderClassName: 'border-teal-200 dark:border-teal-700/50',
+    textClassName: 'text-teal-700 dark:text-teal-400',
+    badgeClassName: 'bg-teal-100 text-teal-800 dark:bg-teal-900/50 dark:text-teal-200',
+  },
 };
 
 const fallbackMeta: MessageDisplayMeta = {

--- a/components/protected/LayoutClient.tsx
+++ b/components/protected/LayoutClient.tsx
@@ -446,7 +446,7 @@ export default function ProtectedLayoutClient({ children, user }: ProtectedLayou
                   {/* 通知プレビューポップオーバー */}
                   {isMounted && isNoticePopoverOpen && (
                     <div
-                      className="absolute right-0 top-full z-50 w-[360px] pt-2"
+                      className="absolute right-0 top-full z-50 w-[360px] origin-top pt-2 animate-[notice-popover-stretch_180ms_ease-out]"
                     >
                       <div className="rounded-lg border border-slate-300 bg-white p-4 shadow-xl dark:border-[#2a2a3e] dark:bg-[#0f1419]">
                         <div className="mb-3 grid grid-cols-[auto_1fr_auto] items-center gap-3">
@@ -470,7 +470,11 @@ export default function ProtectedLayoutClient({ children, user }: ProtectedLayou
                         </div>
                         <div className="mb-3 border-b border-slate-200 pb-3 dark:border-gray-700">
                           <button
-                            onClick={() => router.push('/notice')}
+                            onClick={() => {
+                              setIsNoticePopoverOpen(false);
+                              setIsDeadlinePanelOpen(false);
+                              router.push('/notice');
+                            }}
                             className="w-full rounded-md border border-blue-200 bg-blue-50 px-3 py-2 text-center text-base font-semibold text-blue-600 transition-colors hover:bg-blue-100 hover:text-blue-700 dark:border-blue-900/60 dark:bg-blue-950/30 dark:text-blue-400 dark:hover:bg-blue-950/50 dark:hover:text-blue-300"
                           >
                             通知/メッセージ画面を開く
@@ -566,7 +570,11 @@ export default function ProtectedLayoutClient({ children, user }: ProtectedLayou
                                 <div
                                   key={message.message_id}
                                   className="cursor-pointer rounded-lg border border-slate-200 bg-slate-50 p-3 transition-colors hover:bg-slate-100 dark:border-gray-700/50 dark:bg-gray-800/50 dark:hover:bg-gray-800"
-                                  onClick={() => router.push('/notice')}
+                                  onClick={() => {
+                                    setIsNoticePopoverOpen(false);
+                                    setIsDeadlinePanelOpen(false);
+                                    router.push('/notice');
+                                  }}
                                 >
                                   <div className="mb-1 flex items-start justify-between gap-2">
                                     <h5 className="line-clamp-1 text-base font-semibold text-slate-900 dark:text-white">{message.title}</h5>

--- a/components/protected/app-admin/InquiryReplyModal.tsx
+++ b/components/protected/app-admin/InquiryReplyModal.tsx
@@ -20,7 +20,6 @@ export default function InquiryReplyModal({
   onSuccess,
 }: InquiryReplyModalProps) {
   const [replyContent, setReplyContent] = useState('');
-  const [sendEmail, setSendEmail] = useState(false);
   const [isSubmitting, setIsSubmitting] = useState(false);
 
   const handleSubmit = async () => {
@@ -35,7 +34,7 @@ export default function InquiryReplyModal({
     try {
       const response = await inquiryApi.replyToInquiry(inquiryId, {
         body: replyContent,
-        send_email: sendEmail,
+        send_email: true,
       });
 
       toast.success(response.message || '返信を送信しました');
@@ -61,20 +60,20 @@ export default function InquiryReplyModal({
 
   return (
     <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-50 p-4">
-      <div className="bg-gray-800 rounded-lg p-6 max-w-3xl w-full max-h-[90vh] overflow-y-auto">
-        <h3 className="text-2xl font-bold text-white mb-4">問い合わせに返信</h3>
+      <div className="bg-white rounded-lg p-6 max-w-3xl w-full max-h-[90vh] overflow-y-auto dark:bg-gray-800">
+        <h3 className="text-2xl font-bold text-slate-950 mb-4 dark:text-white">問い合わせに返信</h3>
 
         {/* 問い合わせ情報 */}
-        <div className="bg-gray-700 rounded-lg p-4 mb-6">
+        <div className="bg-slate-100 rounded-lg p-4 mb-6 dark:bg-gray-700">
           <div className="space-y-2">
             <div className="flex items-start gap-2">
-              <span className="text-base text-gray-400 w-20 flex-shrink-0">件名:</span>
-              <span className="text-white font-semibold">{inquiryTitle}</span>
+              <span className="text-base text-slate-600 w-20 flex-shrink-0 dark:text-gray-400">件名:</span>
+              <span className="text-slate-950 font-semibold dark:text-white">{inquiryTitle}</span>
             </div>
             {senderEmail && (
               <div className="flex items-center gap-2">
-                <span className="text-base text-gray-400 w-20 flex-shrink-0">送信先:</span>
-                <span className="text-white">{senderEmail}</span>
+                <span className="text-base text-slate-600 w-20 flex-shrink-0 dark:text-gray-400">送信先:</span>
+                <span className="text-slate-950 dark:text-white">{senderEmail}</span>
               </div>
             )}
           </div>
@@ -82,7 +81,7 @@ export default function InquiryReplyModal({
 
         {/* 返信内容入力 */}
         <div className="mb-6">
-          <label className="text-gray-300 text-base block mb-2">
+          <label className="text-slate-700 text-base block mb-2 dark:text-gray-300">
             返信内容 <span className="text-red-400">*</span>
           </label>
           <textarea
@@ -91,39 +90,27 @@ export default function InquiryReplyModal({
             onChange={(e) => setReplyContent(e.target.value)}
             placeholder="返信内容を入力してください..."
             maxLength={20000}
-            className="w-full bg-gray-700 border border-gray-600 rounded-lg px-4 py-3 text-white placeholder-gray-400 focus:outline-none focus:border-purple-500 resize-none"
+            className="w-full bg-white border border-slate-300 rounded-lg px-4 py-3 text-slate-950 placeholder-slate-400 focus:outline-none focus:border-purple-500 resize-none dark:bg-gray-700 dark:border-gray-600 dark:text-white dark:placeholder-gray-400"
           />
-          <p className="text-gray-400 text-base mt-1">
+          <p className="text-slate-500 text-base mt-1 dark:text-gray-400">
             {replyContent.length} / 20,000文字
           </p>
         </div>
 
-        {/* メール送信オプション */}
+        {/* メール連動 */}
         {senderEmail && (
-          <div className="mb-6">
-            <label className="flex items-center gap-3 cursor-pointer">
-              <input
-                type="checkbox"
-                checked={sendEmail}
-                onChange={(e) => setSendEmail(e.target.checked)}
-                className="w-5 h-5 rounded border-gray-600 bg-gray-700 text-purple-600 focus:ring-purple-500 focus:ring-offset-gray-800"
-              />
-              <div className="flex-1">
-                <span className="text-white font-semibold">メールで返信を送信</span>
-                <p className="text-gray-400 text-base mt-1">
-                  チェックを入れると、送信者のメールアドレスに返信が送信されます。
-                  チェックを外すと、内部通知のみが送信されます。
-                </p>
-              </div>
-            </label>
+          <div className="bg-blue-50 border border-blue-200 rounded-lg p-3 mb-6 dark:bg-blue-900/30 dark:border-blue-700/50">
+            <p className="text-blue-800 text-base dark:text-blue-100">
+              返信はアプリ内通知とメールの両方で送信されます。
+            </p>
           </div>
         )}
 
         {/* 注意事項 */}
         {!senderEmail && (
-          <div className="bg-yellow-900/30 border border-yellow-700/50 rounded-lg p-3 mb-6">
-            <p className="text-yellow-200 text-base">
-              ⚠️ 送信者のメールアドレスが未設定のため、内部通知として送信されます。
+          <div className="bg-yellow-50 border border-yellow-300 rounded-lg p-3 mb-6 dark:bg-yellow-900/30 dark:border-yellow-700/50">
+            <p className="text-yellow-800 text-base dark:text-yellow-200">
+              送信者のメールアドレスが未設定のため、アプリ内通知のみ送信されます。
             </p>
           </div>
         )}
@@ -133,7 +120,7 @@ export default function InquiryReplyModal({
           <button
             onClick={handleCancel}
             disabled={isSubmitting}
-            className="bg-gray-600 hover:bg-gray-500 text-white px-6 py-2 rounded-lg transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+            className="bg-slate-200 hover:bg-slate-300 text-slate-900 px-6 py-2 rounded-lg transition-colors disabled:opacity-50 disabled:cursor-not-allowed dark:bg-gray-600 dark:hover:bg-gray-500 dark:text-white"
           >
             キャンセル
           </button>

--- a/components/protected/app-admin/tabs/AnnouncementsTab.tsx
+++ b/components/protected/app-admin/tabs/AnnouncementsTab.tsx
@@ -191,9 +191,11 @@ export default function AnnouncementsTab() {
                       </span>
                     </div>
                     <p className="text-slate-700 text-base whitespace-pre-wrap dark:text-gray-300">{announcement.content}</p>
-                    <p className="text-base text-slate-500 mt-2 dark:text-gray-400">
-                      送信者: {announcement.sender_name}
-                    </p>
+                    {typeof announcement.recipient_count === 'number' && (
+                      <p className="text-base text-slate-500 mt-2 dark:text-gray-400">
+                        送信先: {announcement.recipient_count}名
+                      </p>
+                    )}
                   </div>
                 </div>
               </div>

--- a/components/protected/app-admin/tabs/InquiriesTab.tsx
+++ b/components/protected/app-admin/tabs/InquiriesTab.tsx
@@ -1,19 +1,20 @@
 'use client';
 
 import { useState, useEffect, useCallback } from 'react';
-import { appAdminApi, InquiryResponse } from '@/lib/api/appAdmin';
+import { inquiryApi } from '@/lib/api/inquiry';
+import type { InquiryListItem, InquiryStatus } from '@/types/inquiry';
 import { FaSync, FaEye, FaEnvelopeOpen, FaEnvelope, FaReply } from 'react-icons/fa';
 import InquiryReplyModal from '../InquiryReplyModal';
 
 export default function InquiriesTab() {
-  const [inquiries, setInquiries] = useState<InquiryResponse[]>([]);
+  const [inquiries, setInquiries] = useState<InquiryListItem[]>([]);
   const [total, setTotal] = useState(0);
   const [isLoading, setIsLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [currentPage, setCurrentPage] = useState(0);
-  const [statusFilter, setStatusFilter] = useState<'new' | 'open' | 'in_progress' | 'answered' | 'closed' | 'spam' | ''>('');
-  const [selectedInquiry, setSelectedInquiry] = useState<InquiryResponse | null>(null);
-  const [replyInquiry, setReplyInquiry] = useState<InquiryResponse | null>(null);
+  const [statusFilter, setStatusFilter] = useState<InquiryStatus | ''>('');
+  const [selectedInquiry, setSelectedInquiry] = useState<InquiryListItem | null>(null);
+  const [replyInquiry, setReplyInquiry] = useState<InquiryListItem | null>(null);
 
   const ITEMS_PER_PAGE = 30;
 
@@ -21,7 +22,7 @@ export default function InquiriesTab() {
     setIsLoading(true);
     setError(null);
     try {
-      const response = await appAdminApi.getInquiries({
+      const response = await inquiryApi.getInquiries({
         status: statusFilter || undefined,
         skip: currentPage * ITEMS_PER_PAGE,
         limit: ITEMS_PER_PAGE,
@@ -60,7 +61,7 @@ export default function InquiriesTab() {
       case 'in_progress':
         return <span className="bg-blue-500/20 text-blue-400 px-2 py-1 rounded text-base">担当割当済み</span>;
       case 'answered':
-        return <span className="bg-green-500/20 text-green-400 px-2 py-1 rounded text-base">回答済み</span>;
+        return <span className="bg-green-100 text-green-700 px-2 py-1 rounded text-base dark:bg-green-500/20 dark:text-green-400">回答済み</span>;
       case 'closed':
         return <span className="bg-gray-500/20 text-gray-400 px-2 py-1 rounded text-base">クローズ</span>;
       case 'spam':
@@ -128,9 +129,9 @@ export default function InquiriesTab() {
                   <div className="flex-1">
                     <div className="flex items-center gap-2 mb-2">
                       {inquiry.status === 'new' ? (
-                        <FaEnvelope className="w-4 h-4 text-red-400" />
+                        <FaEnvelope className="w-4 h-4 text-red-500 dark:text-red-400" />
                       ) : (
-                        <FaEnvelopeOpen className="w-4 h-4 text-slate-400 dark:text-gray-400" />
+                        <FaEnvelopeOpen className="w-4 h-4 text-slate-500 dark:text-gray-400" />
                       )}
                       <span className="font-semibold text-slate-950 dark:text-white">{inquiry.title}</span>
                       {getStatusBadge(inquiry.status)}

--- a/lib/api/appAdmin.ts
+++ b/lib/api/appAdmin.ts
@@ -20,31 +20,6 @@ export interface OfficeListResponse {
   limit: number;
 }
 
-export interface InquiryResponse {
-  id: string;
-  message_id: string;
-  title: string;
-  content: string;
-  status: 'new' | 'open' | 'in_progress' | 'answered' | 'closed' | 'spam';
-  priority: 'low' | 'normal' | 'high';
-  sender_name: string | null;
-  sender_email: string | null;
-  assigned_staff_id: string | null;
-  assigned_staff?: {
-    id: string;
-    first_name: string;
-    last_name: string;
-    email: string;
-  } | null;
-  created_at: string;
-  updated_at: string;
-}
-
-export interface InquiryListResponse {
-  inquiries: InquiryResponse[];
-  total: number;
-}
-
 export interface AnnouncementCreate {
   title: string;
   content: string;
@@ -52,11 +27,21 @@ export interface AnnouncementCreate {
 
 export interface AnnouncementResponse {
   id: string;
+  sender_staff_id: string | null;
+  office_id: string;
+  message_type: 'announcement';
+  priority: 'low' | 'normal' | 'high' | 'urgent';
   title: string;
   content: string;
-  sender_id: string;
-  sender_name: string;
   created_at: string;
+  updated_at: string;
+  sender?: {
+    id: string;
+    first_name: string;
+    last_name: string;
+    email: string;
+  } | null;
+  recipient_count?: number | null;
 }
 
 export interface AnnouncementListResponse {
@@ -103,81 +88,6 @@ export const appAdminApi = {
   getOffice: (officeId: string): Promise<OfficeDetailResponse> => {
     return http.get<OfficeDetailResponse>(
       `${API_V1_PREFIX}/admin/offices/${officeId}`
-    );
-  },
-
-  /**
-   * 問い合わせ一覧取得
-   * @param params - フィルターパラメータ
-   */
-  getInquiries: async (params?: {
-    status?: 'new' | 'open' | 'in_progress' | 'answered' | 'closed' | 'spam';
-    priority?: 'low' | 'normal' | 'high';
-    assigned?: string;
-    search?: string;
-    skip?: number;
-    limit?: number;
-    sort?: 'created_at' | 'updated_at' | 'priority';
-    order?: 'asc' | 'desc';
-  }): Promise<InquiryListResponse> => {
-    const queryParams = new URLSearchParams();
-
-    if (params?.status) {
-      queryParams.append('status', params.status);
-    }
-    if (params?.priority) {
-      queryParams.append('priority', params.priority);
-    }
-    if (params?.assigned) {
-      queryParams.append('assigned', params.assigned);
-    }
-    if (params?.search) {
-      queryParams.append('search', params.search);
-    }
-    if (params?.skip !== undefined) {
-      queryParams.append('skip', params.skip.toString());
-    }
-    if (params?.limit !== undefined) {
-      queryParams.append('limit', params.limit.toString());
-    }
-    if (params?.sort) {
-      queryParams.append('sort', params.sort);
-    }
-    if (params?.order) {
-      queryParams.append('order', params.order);
-    }
-
-    const queryString = queryParams.toString();
-    const endpoint = queryString
-      ? `${API_V1_PREFIX}/admin/inquiries?${queryString}`
-      : `${API_V1_PREFIX}/admin/inquiries`;
-
-    return http.get<InquiryListResponse>(endpoint);
-  },
-
-  /**
-   * 問い合わせに返信
-   * @param inquiryId - 問い合わせID
-   * @param content - 返信内容
-   */
-  replyToInquiry: (
-    inquiryId: string,
-    content: string
-  ): Promise<InquiryResponse> => {
-    return http.post<InquiryResponse>(
-      `${API_V1_PREFIX}/admin/inquiries/${inquiryId}/reply`,
-      { content }
-    );
-  },
-
-  /**
-   * 問い合わせを既読にする
-   * @param inquiryId - 問い合わせID
-   */
-  markInquiryAsRead: (inquiryId: string): Promise<InquiryResponse> => {
-    return http.patch<InquiryResponse>(
-      `${API_V1_PREFIX}/admin/inquiries/${inquiryId}/read`,
-      {}
     );
   },
 

--- a/lib/api/inquiry.ts
+++ b/lib/api/inquiry.ts
@@ -13,9 +13,8 @@ import type {
   InquiryDeleteResponse,
   InquiryReplyRequest,
   InquiryReplyResponse,
-  InquiryStatus,
-  InquiryPriority,
 } from '@/types/inquiry';
+import { buildInquiryListEndpoint, type InquiryListQueryParams } from './inquiryQuery';
 
 const API_V1_PREFIX = '/api/v1';
 
@@ -32,37 +31,8 @@ export const inquiryApi = {
   /**
    * 問い合わせ一覧を取得（管理者専用）
    */
-  getInquiries: (params?: {
-    status?: InquiryStatus;
-    assigned?: string;
-    priority?: InquiryPriority;
-    search?: string;
-    skip?: number;
-    limit?: number;
-    sort?: 'created_at' | 'updated_at' | 'priority';
-    order?: 'asc' | 'desc';
-    include_test_data?: boolean;
-  }): Promise<InquiryListResponse> => {
-    const queryParams = new URLSearchParams();
-
-    if (params?.status) queryParams.append('status', params.status);
-    if (params?.assigned) queryParams.append('assigned', params.assigned);
-    if (params?.priority) queryParams.append('priority', params.priority);
-    if (params?.search) queryParams.append('search', params.search);
-    if (params?.skip !== undefined) queryParams.append('skip', String(params.skip));
-    if (params?.limit !== undefined) queryParams.append('limit', String(params.limit));
-    if (params?.sort) queryParams.append('sort', params.sort);
-    if (params?.order) queryParams.append('order', params.order);
-    if (params?.include_test_data !== undefined) {
-      queryParams.append('include_test_data', String(params.include_test_data));
-    }
-
-    const queryString = queryParams.toString();
-    const endpoint = queryString
-      ? `${API_V1_PREFIX}/admin/inquiries?${queryString}`
-      : `${API_V1_PREFIX}/admin/inquiries`;
-
-    return http.get<InquiryListResponse>(endpoint);
+  getInquiries: (params?: InquiryListQueryParams): Promise<InquiryListResponse> => {
+    return http.get<InquiryListResponse>(buildInquiryListEndpoint(params));
   },
 
   /**

--- a/lib/api/inquiryQuery.test.mjs
+++ b/lib/api/inquiryQuery.test.mjs
@@ -1,0 +1,28 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { buildInquiryListEndpoint } from './inquiryQuery.ts';
+
+test('buildInquiryListEndpoint includes all supported admin inquiry filters', () => {
+  assert.equal(
+    buildInquiryListEndpoint({
+      status: 'new',
+      assigned: 'staff-1',
+      priority: 'high',
+      search: '請求',
+      skip: 20,
+      limit: 20,
+      sort: 'updated_at',
+      order: 'desc',
+      include_test_data: true,
+    }),
+    '/api/v1/admin/inquiries?status=new&assigned=staff-1&priority=high&search=%E8%AB%8B%E6%B1%82&skip=20&limit=20&sort=updated_at&order=desc&include_test_data=true'
+  );
+});
+
+test('buildInquiryListEndpoint omits empty params', () => {
+  assert.equal(buildInquiryListEndpoint(), '/api/v1/admin/inquiries');
+  assert.equal(
+    buildInquiryListEndpoint({ status: undefined, search: '', skip: 0 }),
+    '/api/v1/admin/inquiries?skip=0'
+  );
+});

--- a/lib/api/inquiryQuery.ts
+++ b/lib/api/inquiryQuery.ts
@@ -1,0 +1,40 @@
+import type {
+  InquiryFilterParams,
+  InquiryPriority,
+  InquiryStatus,
+} from '@/types/inquiry';
+
+const API_V1_PREFIX = '/api/v1';
+
+export interface InquiryListQueryParams extends InquiryFilterParams {
+  status?: InquiryStatus;
+  assigned?: string;
+  priority?: InquiryPriority;
+  search?: string;
+  skip?: number;
+  limit?: number;
+  sort?: 'created_at' | 'updated_at' | 'priority';
+  order?: 'asc' | 'desc';
+  include_test_data?: boolean;
+}
+
+export function buildInquiryListEndpoint(params?: InquiryListQueryParams): string {
+  const queryParams = new URLSearchParams();
+
+  if (params?.status) queryParams.append('status', params.status);
+  if (params?.assigned) queryParams.append('assigned', params.assigned);
+  if (params?.priority) queryParams.append('priority', params.priority);
+  if (params?.search) queryParams.append('search', params.search);
+  if (params?.skip !== undefined) queryParams.append('skip', String(params.skip));
+  if (params?.limit !== undefined) queryParams.append('limit', String(params.limit));
+  if (params?.sort) queryParams.append('sort', params.sort);
+  if (params?.order) queryParams.append('order', params.order);
+  if (params?.include_test_data !== undefined) {
+    queryParams.append('include_test_data', String(params.include_test_data));
+  }
+
+  const queryString = queryParams.toString();
+  return queryString
+    ? `${API_V1_PREFIX}/admin/inquiries?${queryString}`
+    : `${API_V1_PREFIX}/admin/inquiries`;
+}

--- a/types/inquiry.ts
+++ b/types/inquiry.ts
@@ -22,7 +22,8 @@ export type InquiryCategory = '不具合' | '質問' | 'その他';
  */
 export interface StaffInfo {
   id: string;
-  name: string;
+  first_name: string;
+  last_name: string;
   email: string;
 }
 
@@ -52,6 +53,7 @@ export interface InquiryListItem {
   id: string;
   message_id: string;
   title: string;
+  content: string;
   status: InquiryStatus;
   priority: InquiryPriority;
   sender_name: string | null;
@@ -172,4 +174,6 @@ export interface InquiryFilterParams {
   skip?: number;
   limit?: number;
   sort?: 'created_at' | 'updated_at' | 'priority';
+  order?: 'asc' | 'desc';
+  include_test_data?: boolean;
 }

--- a/types/message.ts
+++ b/types/message.ts
@@ -7,6 +7,7 @@ export enum MessageType {
   ANNOUNCEMENT = 'announcement',
   SYSTEM = 'system',
   INQUIRY = 'inquiry',
+  INQUIRY_REPLY = 'inquiry_reply',
 }
 
 export enum MessagePriority {


### PR DESCRIPTION
## Summary
- アプリ管理者の問い合わせAPIの利用を「inquiryApi」に統合し、タイプをバックエンドの応答と整合させる
- お知らせ履歴のタイプと、問い合わせへの返信がユーザー通知として表示されるように修正する
- 通知ポップオーバーの閉じ動作、ストレッチアニメーション、およびライト／ダークUIの詳細を更新する

## Tests
- npx tsc --noEmit
- node --test lib/api/inquiryQuery.test.mjs components/notice/messageDisplay.test.mjs
- git diff --check