### PR TITLE
Add support plan .ics download UI

### DIFF
--- a/components/protected/support_plan/SupportPlan.tsx
+++ b/components/protected/support_plan/SupportPlan.tsx
@@ -3,12 +3,13 @@
 import { useState, useEffect } from 'react';
 import { useParams } from 'next/navigation';
 import { FaCheckSquare, FaRegSquare } from 'react-icons/fa';
-import { MdWarning, MdNotifications } from 'react-icons/md';
+import { MdClose, MdDownload, MdHelpOutline, MdWarning, MdNotifications } from 'react-icons/md';
 import PlanDeliverableModal from './PlanDeliverableModal';
 import MonitoringDeadlineModal from './MonitoringDeadlineModal';
 import Breadcrumb, { BreadcrumbItem } from '@/components/ui/Breadcrumb';
 import { welfareRecipientsApi, WelfareRecipient } from '@/lib/welfare-recipients';
 import { supportPlanApi, PlanCycle } from '@/lib/support-plan';
+import { calendarApi } from '@/lib/calendar';
 import { toast } from '@/lib/toast-debug';
 import { SUPPORT_PLAN_STEP_LABELS } from './stepLabels';
 
@@ -24,6 +25,8 @@ export default function SupportPlan() {
   const [selectedStepType, setSelectedStepType] = useState<string>('');
 
   const [isDeadlineModalOpen, setIsDeadlineModalOpen] = useState(false);
+  const [isIcsHelpOpen, setIsIcsHelpOpen] = useState(false);
+  const [isDownloadingIcs, setIsDownloadingIcs] = useState(false);
   const [currentMonitoringDeadline] = useState(7);
 
   const [isLoading, setIsLoading] = useState(true);
@@ -177,6 +180,21 @@ export default function SupportPlan() {
     }
   };
 
+  const handleDownloadIcs = async () => {
+    if (!recipientId) return;
+    setIsDownloadingIcs(true);
+    try {
+      await calendarApi.downloadIcs({ recipient_id: recipientId });
+      toast.success('カレンダーファイルをダウンロードしました');
+    } catch (err) {
+      console.error('Client operation failed');
+      const message = err instanceof Error ? err.message : 'カレンダーファイルのダウンロードに失敗しました';
+      toast.error(message);
+    } finally {
+      setIsDownloadingIcs(false);
+    }
+  };
+
 
 
   // ローディング中
@@ -269,6 +287,25 @@ export default function SupportPlan() {
               <p className="text-slate-600 text-base font-semibold dark:text-[#9ca3af]">
                 フリガナ: {furigana}
               </p>
+            </div>
+            <div className="flex flex-col gap-2 sm:flex-row">
+              <button
+                type="button"
+                onClick={() => setIsIcsHelpOpen(true)}
+                className="inline-flex items-center justify-center gap-2 rounded-md border border-slate-300 bg-white px-4 py-2 text-base font-semibold text-slate-700 transition-colors hover:bg-slate-100 dark:border-gray-600 dark:bg-gray-700 dark:text-gray-200 dark:hover:bg-gray-600"
+              >
+                <MdHelpOutline className="h-5 w-5" />
+                取り込み手順
+              </button>
+              <button
+                type="button"
+                onClick={handleDownloadIcs}
+                disabled={isDownloadingIcs}
+                className="inline-flex items-center justify-center gap-2 rounded-md bg-blue-600 px-4 py-2 text-base font-semibold text-white transition-colors hover:bg-blue-700 disabled:cursor-not-allowed disabled:opacity-60"
+              >
+                <MdDownload className="h-5 w-5" />
+                {isDownloadingIcs ? '作成中...' : '.icsをダウンロード'}
+              </button>
             </div>
           </div>
         </div>
@@ -658,6 +695,36 @@ export default function SupportPlan() {
         onConfirm={handleSetMonitoringDeadline}
         currentDeadline={currentMonitoringDeadline}
       />
+
+      {isIcsHelpOpen && (
+        <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 p-4">
+          <div className="max-h-[90vh] w-full max-w-2xl overflow-y-auto rounded-lg border border-slate-300 bg-white p-6 shadow-xl dark:border-gray-700 dark:bg-gray-800">
+            <div className="mb-5 flex items-center justify-between gap-4">
+              <h2 className="text-xl font-bold text-slate-950 dark:text-white">Google Calendarへの手動インポート</h2>
+              <button
+                type="button"
+                onClick={() => setIsIcsHelpOpen(false)}
+                className="rounded-md p-2 text-slate-500 transition-colors hover:bg-slate-100 hover:text-slate-900 dark:text-gray-400 dark:hover:bg-gray-700 dark:hover:text-white"
+                aria-label="閉じる"
+              >
+                <MdClose className="h-6 w-6" />
+              </button>
+            </div>
+            <ol className="list-decimal space-y-2 pl-6 text-base font-semibold text-slate-700 dark:text-gray-200">
+              <li>このページから `.ics` ファイルをダウンロードする。</li>
+              <li>Google Calendarを開く。</li>
+              <li>設定の「インポート/エクスポート」を開く。</li>
+              <li>ダウンロードした `.ics` ファイルを選択する。</li>
+              <li>反映先カレンダーを選び、インポートする。</li>
+            </ol>
+            <div className="mt-5 rounded-lg border border-amber-300 bg-amber-50 p-4 dark:border-amber-700/60 dark:bg-amber-950/30">
+              <p className="text-base font-semibold text-amber-800 dark:text-amber-200">
+                `.ics` は手動インポート用です。支援計画の期限が変わった場合は、再ダウンロードと再インポートが必要です。再インポート時にGoogle Calendar側で予定が重複する場合があります。
+              </p>
+            </div>
+          </div>
+        </div>
+      )}
     </div>
   );
 }

--- a/lib/calendar.test.mjs
+++ b/lib/calendar.test.mjs
@@ -1,0 +1,22 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { buildCalendarIcsExportEndpoint } from './calendarExport.ts';
+
+test('buildCalendarIcsExportEndpoint targets recipient scoped ics export', () => {
+  assert.equal(
+    buildCalendarIcsExportEndpoint({
+      recipient_id: 'recipient-1',
+      from_date: '2026-08-01',
+      to_date: '2026-08-31',
+      event_type: 'renewal_deadline',
+    }),
+    '/api/v1/calendar/export.ics?from_date=2026-08-01&to_date=2026-08-31&event_type=renewal_deadline&recipient_id=recipient-1'
+  );
+});
+
+test('buildCalendarIcsExportEndpoint omits empty filters', () => {
+  assert.equal(
+    buildCalendarIcsExportEndpoint({ recipient_id: 'recipient-1' }),
+    '/api/v1/calendar/export.ics?recipient_id=recipient-1'
+  );
+});

--- a/lib/calendar.ts
+++ b/lib/calendar.ts
@@ -6,14 +6,70 @@ import {
   ServiceAccountUploadRequest,
   CalendarUpdateRequest,
   CalendarDeleteResponse,
+  CalendarEvent,
+  CalendarEventQuery,
 } from '@/types/calendar';
+import { buildCalendarIcsExportEndpoint, type CalendarIcsExportQuery } from './calendarExport';
 
 const API_V1_PREFIX = '/api/v1';
+const API_BASE_URL = (process.env.NEXT_PUBLIC_API_URL || 'http://localhost:8000').replace(/\/$/, '');
+
+function getFilenameFromContentDisposition(contentDisposition: string | null): string {
+  const match = contentDisposition?.match(/filename="([^"]+)"/);
+  return match?.[1] || 'keikakun-calendar.ics';
+}
+
+function triggerFileDownload(blob: Blob, filename: string): void {
+  const url = window.URL.createObjectURL(blob);
+  const link = document.createElement('a');
+  link.href = url;
+  link.download = filename;
+  document.body.appendChild(link);
+  link.click();
+  link.remove();
+  window.URL.revokeObjectURL(url);
+}
 
 /**
  * カレンダー連携API
  */
 export const calendarApi = {
+  /**
+   * アプリ内期限カレンダーのイベント一覧を取得
+   */
+  getEvents: (query: CalendarEventQuery = {}): Promise<CalendarEvent[]> => {
+    const params = new URLSearchParams();
+    if (query.from_date) params.set('from_date', query.from_date);
+    if (query.to_date) params.set('to_date', query.to_date);
+    if (query.event_type) params.set('event_type', query.event_type);
+    if (query.recipient_id) params.set('recipient_id', query.recipient_id);
+    const queryString = params.toString();
+    const endpoint = queryString
+      ? `${API_V1_PREFIX}/calendar/events?${queryString}`
+      : `${API_V1_PREFIX}/calendar/events`;
+    return http.get<CalendarEvent[]>(endpoint);
+  },
+
+  /**
+   * 支援計画ページ向けに期限イベントを .ics ファイルとしてダウンロード
+   */
+  downloadIcs: async (query: CalendarIcsExportQuery = {}): Promise<void> => {
+    const endpoint = buildCalendarIcsExportEndpoint(query);
+    const response = await fetch(`${API_BASE_URL}${endpoint}`, {
+      method: 'GET',
+      credentials: 'include',
+    });
+
+    if (!response.ok) {
+      const errorData = await response.json().catch(() => ({ detail: 'カレンダーファイルのダウンロードに失敗しました' }));
+      throw new Error(errorData.detail || 'カレンダーファイルのダウンロードに失敗しました');
+    }
+
+    const blob = await response.blob();
+    const filename = getFilenameFromContentDisposition(response.headers.get('content-disposition'));
+    triggerFileDownload(blob, filename);
+  },
+
   /**
    * 事業所のカレンダー設定を取得
    */

--- a/lib/calendarExport.ts
+++ b/lib/calendarExport.ts
@@ -1,0 +1,17 @@
+import type { CalendarEventQuery } from '@/types/calendar';
+
+const API_V1_PREFIX = '/api/v1';
+
+export type CalendarIcsExportQuery = CalendarEventQuery;
+
+export function buildCalendarIcsExportEndpoint(query: CalendarIcsExportQuery = {}): string {
+  const params = new URLSearchParams();
+  if (query.from_date) params.set('from_date', query.from_date);
+  if (query.to_date) params.set('to_date', query.to_date);
+  if (query.event_type) params.set('event_type', query.event_type);
+  if (query.recipient_id) params.set('recipient_id', query.recipient_id);
+  const queryString = params.toString();
+  return queryString
+    ? `${API_V1_PREFIX}/calendar/export.ics?${queryString}`
+    : `${API_V1_PREFIX}/calendar/export.ics`;
+}

--- a/types/calendar.ts
+++ b/types/calendar.ts
@@ -25,6 +25,50 @@ export enum CalendarConnectionStatus {
   SYNCING = 'syncing',
 }
 
+export enum CalendarEventType {
+  RENEWAL_DEADLINE = 'renewal_deadline',
+  NEXT_PLAN_START_DATE = 'next_plan_start_date',
+  ASSESSMENT_INCOMPLETE = 'assessment_incomplete',
+  CUSTOM = 'custom',
+}
+
+export enum CalendarSyncStatus {
+  PENDING = 'pending',
+  SYNCED = 'synced',
+  FAILED = 'failed',
+  CANCELLED = 'cancelled',
+  LOCAL_ONLY = 'local_only',
+}
+
+export interface CalendarEvent {
+  id: string;
+  office_id: string;
+  welfare_recipient_id: string;
+  support_plan_cycle_id: number | null;
+  support_plan_status_id: number | null;
+  event_type: CalendarEventType;
+  google_calendar_id: string | null;
+  google_event_id: string | null;
+  google_event_url: string | null;
+  event_title: string;
+  event_description: string | null;
+  event_start_datetime: string;
+  event_end_datetime: string;
+  created_by_system: boolean;
+  sync_status: CalendarSyncStatus;
+  last_sync_at: string | null;
+  last_error_message: string | null;
+  created_at: string;
+  updated_at: string;
+}
+
+export interface CalendarEventQuery {
+  from_date?: string;
+  to_date?: string;
+  event_type?: CalendarEventType;
+  recipient_id?: string;
+}
+
 export interface CalendarSetupRequest {
   office_id: string;
   google_calendar_id: string;


### PR DESCRIPTION
## Summary
- Add support plan page controls for .ics download and manual import instructions
- Add calendar export endpoint builder and browser download handling
- Scope downloads by the current support-plan recipient

## Tests
- node --test lib/calendar.test.mjs
- npx tsc --noEmit
- git diff --check